### PR TITLE
Welling/validate ometiff xml

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-xmltodict>=0.12.0
+xmlschema>=1.6
 tifffile>=2020.10.1

--- a/src/ingest_validation_tests/ome_tiff_validator.py
+++ b/src/ingest_validation_tests/ome_tiff_validator.py
@@ -9,7 +9,7 @@ class OmeTiffValidator(Validator):
     cost = 1.0
     def collect_errors(self) -> List[str]:
         rslt = []
-        for glob_expr in ['**/*.ome.tiff', '**/*.OME.TIFF']:
+        for glob_expr in ['**/*.ome.tif', '**/*.ome.tiff', '**/*.OME.TIFF', '**/*.OME.TIF']:
             for path in self.path.glob(glob_expr):
                 try:
                     with tifffile.TiffFile(path) as tf:

--- a/src/ingest_validation_tests/ome_tiff_validator.py
+++ b/src/ingest_validation_tests/ome_tiff_validator.py
@@ -1,6 +1,6 @@
 from typing import List
 
-import xmltodict
+import xmlschema
 import tifffile
 from ingest_validation_tools.plugin_validator import Validator
 
@@ -13,7 +13,9 @@ class OmeTiffValidator(Validator):
             for path in self.path.glob(glob_expr):
                 try:
                     with tifffile.TiffFile(path) as tf:
-                        metadata = xmltodict.parse(tf.ome_metadata)  # @Notused
+                        xml_document = xmlschema.XmlDocument(tf.ome_metadata)
+                    if not xml_document.schema.is_valid(xml_document):
+                        rslt.append(f'{path} is not a valid OME.TIFF file')
                 except:
                     rslt.append(f'{path} is not a valid OME.TIFF file')
         return rslt


### PR DESCRIPTION
This changes the ome-tiff validator plugin to validate the XML extracted from the tiff file against the schema it contains, using the 'xmlschema' module.