### PR TITLE
Plugin validator kwargs support

### DIFF
--- a/src/ingest_validation_tests/gz_validator.py
+++ b/src/ingest_validation_tests/gz_validator.py
@@ -7,7 +7,7 @@ from ingest_validation_tools.plugin_validator import Validator
 class GZValidator(Validator):
     description = "Recursively checking gzipped files for damage"
     cost = 5.0
-    def collect_errors(self) -> List[str]:
+    def collect_errors(self, **kwargs) -> List[str]:
         rslt = []
         for glob_expr in ['**/*.gz']:
             for path in self.path.glob(glob_expr):

--- a/src/ingest_validation_tests/ome_tiff_validator.py
+++ b/src/ingest_validation_tests/ome_tiff_validator.py
@@ -7,7 +7,7 @@ from ingest_validation_tools.plugin_validator import Validator
 class OmeTiffValidator(Validator):
     description = "Recursively test all ome-tiff files for validity"
     cost = 1.0
-    def collect_errors(self) -> List[str]:
+    def collect_errors(self, **kwargs) -> List[str]:
         rslt = []
         for glob_expr in ['**/*.ome.tif', '**/*.ome.tiff', '**/*.OME.TIFF', '**/*.OME.TIF']:
             for path in self.path.glob(glob_expr):


### PR DESCRIPTION
There is a need to access the auth token from new plugin validation tests, and the most efficient way to do so is by passing the Airflow environment down to the test via kwargs.  This PR adds the necessry kwargs parameters to the existing tests.