### PR TITLE
Mruffalo/validate codex json additions

### DIFF
--- a/src/ingest_validation_tests/codex_json_validator.py
+++ b/src/ingest_validation_tests/codex_json_validator.py
@@ -12,6 +12,9 @@ class CodexJsonValidator(Validator):
     cost = 1.0
 
     def collect_errors(self, **kwargs) -> List[str]:
+        if 'codex' not in self.assay_type.lower():
+            return []
+
         schema_path = Path(__file__).parent / 'codex_schema.json'
         schema = json.loads(schema_path.read_text())
 

--- a/src/ingest_validation_tests/codex_json_validator.py
+++ b/src/ingest_validation_tests/codex_json_validator.py
@@ -13,7 +13,7 @@ class CodexJsonValidator(Validator):
 
     def collect_errors(self, **kwargs) -> List[str]:
         schema_path = Path(__file__).parent / 'codex_schema.json'
-        schema = json.loads(schema_path.read_text)
+        schema = json.loads(schema_path.read_text())
 
         rslt = []
         for glob_expr in ['**/dataset.json']:


### PR DESCRIPTION
Makes #10 more precise, by checking the assay type.

CI error:
```
Collecting yattag==1.14.0
  Downloading yattag-1.14.0.tar.gz (26 kB)
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
```

Not clear to me how that is related to the changes in this PR... I'll re-run CI... If that still fails, will try to reproduce locally... Maybe there's a problem with an unpinned transitive dependency?