### PR TITLE
Shell variable-substitution cleanup

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 set -o errexit
 
-red=`tput setaf 1`
-green=`tput setaf 2`
-reset=`tput sgr0`
-start() { [[ -z $CI ]] || echo travis_fold':'start:$1; echo $green$1$reset; }
-end() { [[ -z $CI ]] || echo travis_fold':'end:$1; }
+red="$(tput setaf 1)"
+green="$(tput setaf 2)"
+reset="$(tput sgr0)"
+
+start() { [[ -z "$CI" ]] || echo "travis_fold:start:$1"; echo "$green$1$reset"; }
+end() { [[ -z "$CI" ]] || echo "travis_fold:end:$1"; }
 die() { set +v; echo "$red$*$reset" 1>&2 ; exit 1; }
 
 


### PR DESCRIPTION
Just some minor shell code cleanup in terms of variable substitutions to be done in a way that is considered to be a better (safer) practice.