### PR TITLE
tiff_validator modified to mark files bad if tifffile emits a warning

### DIFF
--- a/src/ingest_validation_tests/tiff_validator.py
+++ b/src/ingest_validation_tests/tiff_validator.py
@@ -5,6 +5,13 @@ from typing import List
 import tifffile
 from ingest_validation_tools.plugin_validator import Validator
 
+# monkey patch tifffile to raise an exception every time a warning
+# is logged
+original_log_warning = tifffile.tifffile.log_warning
+def my_log_warning(msg, *args, **kwargs):
+    raise RuntimeError(f"{msg.format(*args, **kwargs)}")
+tifffile.tifffile.log_warning = my_log_warning
+
 
 def _log(message: str):
     print(message)
@@ -16,19 +23,17 @@ def _check_tiff_file(path: str) -> str or None:
             for page in tfile.pages:
                 _ = page.shape
                 _ = page.dtype
-            return None
+        return None
     except Exception as excp:
         _log(f"{path} is not a valid TIFF file: {excp}")
-        return f"{path} is not a valid TIFF file"
+        return f"{path} is not a valid TIFF file: {excp}"
 
 
 class TiffValidator(Validator):
     description = "Recursively test all tiff files that are not ome.tiffs for validity"
     cost = 1.0
-
     def collect_errors(self, **kwargs) -> List[str]:
         threads = kwargs.get('coreuse', None) or cpu_count() // 4 or 1
-        _log(f'Threading at {threads}')
         pool = Pool(threads)
         filenames_to_test = []
         for glob_expr in ['**/*.tif', '**/*.tiff', '**/*.TIFF', '**/*.TIF']:


### PR DESCRIPTION
This PR addresses a problem with the previous version where only frank errors from the tifffile module caused a file to be marked invalid, but warnings like bad block offsets were ignored.  The new version causes files that cause warnings to be marked invalid.  It does so by the ugly hack of monkey-patching the routine tifffile uses to log warnings so that it raises an exception instead.  That exception is caught by the validator and the file is marked invalid.