### PR TITLE
Plugin optimization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,20 @@
 language: python
 python:
-  - '3.9'
+  - "3.9"
 cache: pip
 install:
   - pip install -r requirements.txt
   # - pip install -r requirements-dev.txt
- 
+
   - pwd
   - cd ..
   - git clone https://github.com/hubmapconsortium/ingest-validation-tools.git
   - cd ingest-validation-tools
   - pwd
-  - git checkout v0.0.15
+  - git checkout v0.0.17
   # - pip install "setuptools==60.9.0"
   - pip install -r requirements.txt
- 
+
   - cd ../ingest-validation-tests # Not sure if this is required, or if it resets between sections.
 script:
   - ./test.sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-xmlschema>=1.6
-tifffile==2020.10.1
+git+https://github.com/hubmapconsortium/fastq-utils.git@v0.2.5#egg=hubmap-fastq-utils
+imagecodecs>=2023.3.16
 jsonschema==4.4.0
 pandas>=1.2.0
-imagecodecs>=2023.3.16
-python-frontmatter>=1.0.0
-git+https://github.com/hubmapconsortium/fastq-utils.git@v0.2.5#egg=hubmap-fastq-utils
+python-frontmatter>=1.1.0
+tifffile==2020.10.1
+xmlschema>=1.6

--- a/src/ingest_validation_tests/codex_common_errors_validator.py
+++ b/src/ingest_validation_tests/codex_common_errors_validator.py
@@ -12,6 +12,7 @@ class QuitNowException(Exception):
     """
     Signal exit from this validation test
     """
+
     pass
 
 
@@ -43,166 +44,178 @@ class CodexCommonErrorsValidator(Validator):
     Test for some common errors in the directory and file structure of
     CODEX datasets.
     """
+
     description = "Test for common problems found in CODEX"
     cost = 1.0
+
     def collect_errors(self, **kwargs) -> List[str]:
         """
         Return the errors found by this validator
         """
+        del kwargs
         if self.assay_type != 'CODEX':
             return []  # We only test CODEX data
-        rslt = []
-        try:
-            # is the raw/src_ directory present?
-            prefix = None
-            if (self.path / 'raw').is_dir():
-                prefix = self.path / 'raw'
-            else:
-                for candidate in self.path.glob('src_*'):
-                    prefix = candidate
-            if prefix is None:
-                rslt.append('The raw/src_ subdirectory is missing?')
-                raise QuitNowException()
-
-            # Does dataset.json exist?  If so, 'new CODEX' syntax rules
-            # are in effect
-            dataset_json_exists = False
-            any_dataset_json_exists = False
-            for candidate in self.path.glob('**/dataset.json'):
-                any_dataset_json_exists = True
-                if candidate == prefix / 'dataset.json':
-                    dataset_json_exists = True
-            if dataset_json_exists:
-                print('FOUND dataset.json; skipping further analysis')
-                raise QuitNowException()
-            elif any_dataset_json_exists:
-                rslt.append('A dataset.json file exists but'
-                            ' is in the wrong place')
-
-            # is the segmentation.json file on the right side?
-            found = False
-            right_place = False
-            for path in self.path.glob('*/[Ss]egmentation.json'):
-                rel_path = path.relative_to(self.path)
-                found = True
-                if str(rel_path).startswith(('raw', 'src_')):
-                    right_place = True
-            if found:
-                if right_place:
-                    pass
-                else:
-                    rslt.append('The segmentation.json file is in the wrong subdirectory')
-            else:
-                rslt.append('The segmentation.json file is missing or misplaced')
-
-            # Does the channelnames.txt file exist?
-            channelnames_txt_path = prefix / 'channelnames.txt'
-            if not channelnames_txt_path.is_file():
-                # sometimes we see this variant
-                channelnames_txt_path = prefix / 'channelNames.txt'
-                if not channelnames_txt_path.is_file():
-                    rslt.append('channelnames.txt is missing')
-                    raise QuitNowException()
-
-            # Parse channelnames.txt into a dataframe
+        rslts = []
+        for path in self.paths:
+            rslt = []
             try:
-                cn_df = pd.read_csv(str(channelnames_txt_path), header=None)
-            except Exception:
-                rslt.append(f'Unexpected error reading {channelnames_txt_path}')
-                raise QuitNowException()
-            if len(cn_df.columns) != 1:
-                rslt.append(f'Unexpected format for {channelnames_txt_path}')
-                raise QuitNowException()
-
-            # Does the channelnames_report.csv file exist?
-            report_csv_path = prefix / 'channelnames_report.csv'
-            if report_csv_path.is_file():
-                # Parse channelnames_report.txt into a dataframe
-                try:
-                    rpt_df = pd.read_csv(str(report_csv_path), sep=',', header=None)
-                except Exception:
-                    rslt.append(f'Unexpected error reading {report_csv_path}')
+                # is the raw/src_ directory present?
+                prefix = None
+                if (path / 'raw').is_dir():
+                    prefix = path / 'raw'
+                else:
+                    for candidate in path.glob('src_*'):
+                        prefix = candidate
+                if prefix is None:
+                    rslt.append('The raw/src_ subdirectory is missing?')
                     raise QuitNowException()
-                if len(rpt_df) == len(cn_df) + 1:
-                    # channelnames_report.csv appears to have a header
+
+                # Does dataset.json exist?  If so, 'new CODEX' syntax rules
+                # are in effect
+                dataset_json_exists = False
+                any_dataset_json_exists = False
+                for candidate in path.glob('**/dataset.json'):
+                    any_dataset_json_exists = True
+                    if candidate == prefix / 'dataset.json':
+                        dataset_json_exists = True
+                if dataset_json_exists:
+                    print('FOUND dataset.json; skipping further analysis')
+                    raise QuitNowException()
+                elif any_dataset_json_exists:
+                    rslt.append(
+                        'A dataset.json file exists but'
+                        ' is in the wrong place'
+                    )
+
+                # is the segmentation.json file on the right side?
+                found = False
+                right_place = False
+                for path in path.glob('*/[Ss]egmentation.json'):
+                    rel_path = path.relative_to(path)
+                    found = True
+                    if str(rel_path).startswith(('raw', 'src_')):
+                        right_place = True
+                if found:
+                    if right_place:
+                        pass
+                    else:
+                        rslt.append(
+                            'The segmentation.json file is in the wrong subdirectory'
+                        )
+                else:
+                    rslt.append('The segmentation.json file is missing or misplaced')
+
+                # Does the channelnames.txt file exist?
+                channelnames_txt_path = prefix / 'channelnames.txt'
+                if not channelnames_txt_path.is_file():
+                    # sometimes we see this variant
+                    channelnames_txt_path = prefix / 'channelNames.txt'
+                    if not channelnames_txt_path.is_file():
+                        rslt.append('channelnames.txt is missing')
+                        raise QuitNowException()
+
+                # Parse channelnames.txt into a dataframe
+                try:
+                    cn_df = pd.read_csv(str(channelnames_txt_path), header=None)
+                except Exception:
+                    rslt.append(f'Unexpected error reading {channelnames_txt_path}')
+                    raise QuitNowException()
+                if len(cn_df.columns) != 1:
+                    rslt.append(f'Unexpected format for {channelnames_txt_path}')
+                    raise QuitNowException()
+
+                # Does the channelnames_report.csv file exist?
+                report_csv_path = prefix / 'channelnames_report.csv'
+                if report_csv_path.is_file():
+                    # Parse channelnames_report.txt into a dataframe
                     try:
-                        rpt_df = pd.read_csv(str(report_csv_path), sep=',')
+                        rpt_df = pd.read_csv(str(report_csv_path), sep=',', header=None)
                     except Exception:
                         rslt.append(f'Unexpected error reading {report_csv_path}')
                         raise QuitNowException()
-                if len(rpt_df.columns) != 2:
-                    rslt.append(f'Could not parse {report_csv_path}.'
-                                ' Is it a comma-separated table?'
-                    )
-                    raise QuitNowException()
-                col_0, col_1 = rpt_df.columns
-                rpt_df = rpt_df.rename(columns={col_0:'Marker', col_1:'Result'})
-                # Do they match?
-                rpt_df['other'] = cn_df[0]
-                mismatches_df = rpt_df[rpt_df['other'] != rpt_df['Marker']]
-                if len(mismatches_df) != 0:
-                    for idx, row in mismatches_df.iterrows():
+                    if len(rpt_df) == len(cn_df) + 1:
+                        # channelnames_report.csv appears to have a header
+                        try:
+                            rpt_df = pd.read_csv(str(report_csv_path), sep=',')
+                        except Exception:
+                            rslt.append(f'Unexpected error reading {report_csv_path}')
+                            raise QuitNowException()
+                    if len(rpt_df.columns) != 2:
                         rslt.append(
-                            f"{channelnames_txt_path.name} does not"
-                            " match channelnames_report.txt"
-                            f" on line {idx}: {row['other']} vs {row['Marker']}"
+                            f'Could not parse {report_csv_path}.'
+                            ' Is it a comma-separated table?'
                         )
+                        raise QuitNowException()
+                    col_0, col_1 = rpt_df.columns
+                    rpt_df = rpt_df.rename(columns={col_0: 'Marker', col_1: 'Result'})
+                    # Do they match?
+                    rpt_df['other'] = cn_df[0]
+                    mismatches_df = rpt_df[rpt_df['other'] != rpt_df['Marker']]
+                    if len(mismatches_df) != 0:
+                        for idx, row in mismatches_df.iterrows():
+                            rslt.append(
+                                f'{channelnames_txt_path.name} does not'
+                                ' match channelnames_report.txt'
+                                f' on line {idx}: {row["other"]} vs {row["Marker"]}'
+                            )
+                        raise QuitNowException()
+                else:
+                    rpt_df = None
+
+                # Tabulate the cycle and region info
+                all_cycle_dirs = []
+                for glob_str in ['cyc*', 'Cyc*']:
+                    for pth in prefix.glob(glob_str):
+                        if pth.is_dir():
+                            all_cycle_dirs.append(str(pth.stem).lower())
+                cycles = []
+                regions = []
+                failures = []
+                for cyc_dir in all_cycle_dirs:
+                    try:
+                        cyc_id, reg_id = _split_cycle_dir_string(cyc_dir)
+                        cycles.append(cyc_id)
+                        regions.append(reg_id)
+                    except AssertionError as excp:
+                        failures.append(str(excp))
+                if failures:
+                    rslt += failures
                     raise QuitNowException()
-            else:
-                rpt_df = None
+                total_entries = len(cycles)
+                cycles = list(set(cycles))
+                cycles.sort()
+                regions = list(set(regions))
+                regions.sort()
+                failures = []
+                # First cycle must be 1
+                if cycles[0] != 1:
+                    failures.append('Cycle numbering does not start at 1')
+                # First region must be 1
+                if regions[0] != 1:
+                    failures.append('Region numbering does not start at 1')
+                # Cycle range must be contiguous ints
+                if cycles != list(range(cycles[0], cycles[-1] + 1)):
+                    failures.append('Cycle numbers are not contiguous')
+                # Region range must be contiguous ints
+                if regions != list(range(regions[0], regions[-1] + 1)):
+                    failures.append('Region numbers are not contiguous')
+                # All cycle, region pairs must be present
+                if len(cycles) * len(regions) != total_entries:
+                    failures.append('Not all cycle/region pairs are present')
+                # Total number of channels / total number of cycles must be integer,
+                # excluding any HandE channels
+                total_channel_count = len(cn_df)
+                h_and_e_channel_count = len(cn_df[cn_df[0].str.startswith('HandE')])
+                channels_per_cycle = (
+                    total_channel_count - h_and_e_channel_count
+                ) / len(cycles)
+                if channels_per_cycle != int(channels_per_cycle):
+                    failures.append('The number of channels per cycle is not constant')
+                if failures:
+                    rslt += failures
+                    raise QuitNowException()
+                rslts.append(rslt)
 
-            # Tabulate the cycle and region info
-            all_cycle_dirs = []
-            for glob_str in ['cyc*', 'Cyc*']:
-                for pth in prefix.glob(glob_str):
-                    if pth.is_dir():
-                        all_cycle_dirs.append(str(pth.stem).lower())
-            cycles = []
-            regions = []
-            failures = []
-            for cyc_dir in all_cycle_dirs:
-                try:
-                    cyc_id, reg_id = _split_cycle_dir_string(cyc_dir)
-                    cycles.append(cyc_id)
-                    regions.append(reg_id)
-                except AssertionError as excp:
-                    failures.append(str(excp))
-            if failures:
-                rslt += failures
-                raise QuitNowException()
-            total_entries = len(cycles)
-            cycles = list(set(cycles))
-            cycles.sort()
-            regions = list(set(regions))
-            regions.sort()
-            failures = []
-            # First cycle must be 1
-            if cycles[0] != 1:
-                failures.append('Cycle numbering does not start at 1')
-            # First region must be 1
-            if regions[0] != 1:
-                failures.append('Region numbering does not start at 1')
-            # Cycle range must be contiguous ints
-            if cycles != list(range(cycles[0], cycles[-1]+1)):
-                failures.append('Cycle numbers are not contiguous')
-            # Region range must be contiguous ints
-            if regions != list(range(regions[0], regions[-1]+1)):
-                failures.append('Region numbers are not contiguous')
-            # All cycle, region pairs must be present
-            if len(cycles) * len(regions) != total_entries:
-                failures.append('Not all cycle/region pairs are present')
-            # Total number of channels / total number of cycles must be integer,
-            # excluding any HandE channels
-            total_channel_count = len(cn_df)
-            h_and_e_channel_count = len(cn_df[cn_df[0].str.startswith('HandE')])
-            channels_per_cycle = ((total_channel_count - h_and_e_channel_count)
-                                  / len(cycles))
-            if channels_per_cycle != int(channels_per_cycle):
-                failures.append('The number of channels per cycle is not constant')
-            if failures:
-                rslt += failures
-                raise QuitNowException()
-
-        except QuitNowException:
-            pass
-        return rslt
+            except QuitNowException:
+                pass
+        return rslts

--- a/src/ingest_validation_tests/codex_common_errors_validator.py
+++ b/src/ingest_validation_tests/codex_common_errors_validator.py
@@ -58,6 +58,7 @@ class CodexCommonErrorsValidator(Validator):
         rslts = []
         for path in self.paths:
             rslt = []
+            # TODO: this seems to be replicating dir validation? Is this necessary for legacy support?
             try:
                 # is the raw/src_ directory present?
                 prefix = None
@@ -90,8 +91,8 @@ class CodexCommonErrorsValidator(Validator):
                 # is the segmentation.json file on the right side?
                 found = False
                 right_place = False
-                for path in path.glob('*/[Ss]egmentation.json'):
-                    rel_path = path.relative_to(path)
+                for filepath in path.glob('*/[Ss]egmentation.json'):
+                    rel_path = filepath.relative_to(path)
                     found = True
                     if str(rel_path).startswith(('raw', 'src_')):
                         right_place = True
@@ -113,6 +114,7 @@ class CodexCommonErrorsValidator(Validator):
                     if not channelnames_txt_path.is_file():
                         rslt.append('channelnames.txt is missing')
                         raise QuitNowException()
+                # TODO: end questionable portion
 
                 # Parse channelnames.txt into a dataframe
                 try:
@@ -214,8 +216,15 @@ class CodexCommonErrorsValidator(Validator):
                 if failures:
                     rslt += failures
                     raise QuitNowException()
-                rslts.append(rslt)
+                if type(rslt) is list:
+                    rslts.extend(rslt)
+                else:
+                    rslts.append(rslt)
 
             except QuitNowException:
+                if type(rslt) is list:
+                    rslts.extend(rslt)
+                else:
+                    rslts.append(rslt)
                 pass
         return rslts

--- a/src/ingest_validation_tests/codex_common_errors_validator.py
+++ b/src/ingest_validation_tests/codex_common_errors_validator.py
@@ -58,7 +58,6 @@ class CodexCommonErrorsValidator(Validator):
         rslts = []
         for path in self.paths:
             rslt = []
-            # TODO: this seems to be replicating dir validation? Is this necessary for legacy support?
             try:
                 # is the raw/src_ directory present?
                 prefix = None
@@ -114,7 +113,6 @@ class CodexCommonErrorsValidator(Validator):
                     if not channelnames_txt_path.is_file():
                         rslt.append('channelnames.txt is missing')
                         raise QuitNowException()
-                # TODO: end questionable portion
 
                 # Parse channelnames.txt into a dataframe
                 try:

--- a/src/ingest_validation_tests/codex_json_validator.py
+++ b/src/ingest_validation_tests/codex_json_validator.py
@@ -11,6 +11,7 @@ class CodexJsonValidator(Validator):
     cost = 1.0
 
     def collect_errors(self, **kwargs) -> List[str]:
+        del kwargs
         if 'codex' not in self.assay_type.lower():
             return []
 

--- a/src/ingest_validation_tests/codex_json_validator.py
+++ b/src/ingest_validation_tests/codex_json_validator.py
@@ -1,10 +1,9 @@
-from typing import List
-from pathlib import Path
 import json
-
-from jsonschema import validate
+from pathlib import Path
+from typing import List
 
 from ingest_validation_tools.plugin_validator import Validator
+from jsonschema import validate
 
 
 class CodexJsonValidator(Validator):
@@ -20,10 +19,11 @@ class CodexJsonValidator(Validator):
 
         rslt = []
         for glob_expr in ['**/dataset.json']:
-            for path in self.path.glob(glob_expr):
-                instance = json.loads(path.read_text())
-                try:
-                    validate(instance=instance, schema=schema)
-                except Exception as e:
-                    rslt.append(f'{path}: {e}')
+            for path in self.paths:
+                for file in path.glob(glob_expr):
+                    instance = json.loads(file.read_text())
+                    try:
+                        validate(instance=instance, schema=schema)
+                    except Exception as e:
+                        rslt.append(f'{file}: {e}')
         return rslt

--- a/src/ingest_validation_tests/fastq_validator.py
+++ b/src/ingest_validation_tests/fastq_validator.py
@@ -1,8 +1,8 @@
 from os import cpu_count
 from typing import List
 
-from fastq_validator_logic import FASTQValidatorLogic, _log
 from ingest_validation_tools.plugin_validator import Validator
+from fastq_validator_logic import FASTQValidatorLogic, _log
 
 
 class FASTQValidator(Validator):
@@ -10,8 +10,8 @@ class FASTQValidator(Validator):
     cost = 15.0
 
     def collect_errors(self, **kwargs) -> List[str]:
-        threads = kwargs.get("coreuse", None) or cpu_count() // 4 or 1
-        _log(f"Threading at {threads}")
+        threads = kwargs.get('coreuse', None) or cpu_count() // 4 or 1
+        _log(f'Threading at {threads}')
         validator = FASTQValidatorLogic(verbose=True)
         validator.validate_fastq_files_in_path(self.paths, threads)
         return validator.errors

--- a/src/ingest_validation_tests/fastq_validator.py
+++ b/src/ingest_validation_tests/fastq_validator.py
@@ -10,7 +10,8 @@ class FASTQValidator(Validator):
     cost = 15.0
 
     def collect_errors(self, **kwargs) -> List[str]:
-        _log(f'Threading at {self.threads}')
+        threads = kwargs.get("coreuse", None) or cpu_count() // 4 or 1
+        _log(f"Threading at {threads}")
         validator = FASTQValidatorLogic(verbose=True)
-        validator.validate_fastq_files_in_path(self.paths, self.pool)
+        validator.validate_fastq_files_in_path(self.paths, threads)
         return validator.errors

--- a/src/ingest_validation_tests/fastq_validator.py
+++ b/src/ingest_validation_tests/fastq_validator.py
@@ -1,8 +1,8 @@
 from os import cpu_count
 from typing import List
 
-from ingest_validation_tools.plugin_validator import Validator
 from fastq_validator_logic import FASTQValidatorLogic, _log
+from ingest_validation_tools.plugin_validator import Validator
 
 
 class FASTQValidator(Validator):
@@ -10,8 +10,7 @@ class FASTQValidator(Validator):
     cost = 15.0
 
     def collect_errors(self, **kwargs) -> List[str]:
-        threads = kwargs.get('coreuse', None) or cpu_count() // 4 or 1
-        _log(f'Threading at {threads}')
+        _log(f'Threading at {self.threads}')
         validator = FASTQValidatorLogic(verbose=True)
-        validator.validate_fastq_files_in_path(self.path, threads)
+        validator.validate_fastq_files_in_path(self.paths, self.pool)
         return validator.errors

--- a/src/ingest_validation_tests/fastq_validator_logic.py
+++ b/src/ingest_validation_tests/fastq_validator_logic.py
@@ -1,7 +1,7 @@
 import argparse
 import gzip
 import re
-from multiprocessing import Manager, pool
+from multiprocessing import Manager, Pool, pool
 from os import cpu_count
 from pathlib import Path
 from typing import Callable, List, TextIO

--- a/src/ingest_validation_tests/fastq_validator_logic.py
+++ b/src/ingest_validation_tests/fastq_validator_logic.py
@@ -180,6 +180,7 @@ class FASTQValidatorLogic:
             _log(f"Added files from {path} to dirs_and_files: {dirs_and_files}")
         file_list = []
         with Manager() as manager:
+            # TODO: re-evaluate dicts/for loops
             lock = manager.Lock()
             for path, rel_paths in dirs_and_files.items():
                 for rel_path, files in rel_paths.items():
@@ -203,6 +204,7 @@ class FASTQValidatorLogic:
             self.errors.extend(data_found_one)
 
     def _find_duplicates(self, dirs_and_files):
+        # TODO: re-evaluate dicts/for loops
         for data_path, sub_dirs in dirs_and_files.items():
             # Creates a dict of filenames to list of full filepaths for each
             # fastq file in a given data_path (dataset dir).

--- a/src/ingest_validation_tests/fastq_validator_logic.py
+++ b/src/ingest_validation_tests/fastq_validator_logic.py
@@ -37,7 +37,7 @@ class Engine(object):
         for path in self.paths:
             _log(f"Validating matching fastq files in {path.as_posix()}")
             self.validate_object.validate_fastq_file(path / fastq_file, self.lock)
-            errors.append(next(iter(self.validate_object.errors), None))
+            errors.append(next(iter(self.validate_object.errors)))
         return errors
 
 
@@ -175,11 +175,11 @@ class FASTQValidatorLogic:
                 self._format_error("Unable to open FASTQ data file."))
             return
 
-        if fastq_file.name in self._file_record_counts.keys():
+        if fastq_file in self._file_record_counts.keys():
             self.errors.append(_log(
-                f"{fastq_file.name} has been found multiple times during this "
+                f"{fastq_file} has been found ultiple times during this "
                 "validation."))
-        self._file_record_counts[fastq_file.name] = records_read
+        self._file_record_counts[fastq_file] = records_read
 
         match = self._FASTQ_FILE_PREFIX_REGEX.match(fastq_file.name)
         with lock:

--- a/src/ingest_validation_tests/fastq_validator_logic.py
+++ b/src/ingest_validation_tests/fastq_validator_logic.py
@@ -168,10 +168,13 @@ class FASTQValidatorLogic:
         try:
             with _open_fastq_file(fastq_file) as fastq_data:
                 records_read = self.validate_fastq_stream(fastq_data)
-            # TODO: Add gzip.BadGzipFile when Python 3.8 is available
+        except gzip.BadGzipFile:
+            self.errors.append(
+                self._format_error(f"Bad gzip file: {fastq_file}."))
+            return
         except IOError:
             self.errors.append(
-                self._format_error("Unable to open FASTQ data file."))
+                self._format_error(f"Unable to open FASTQ data file {fastq_file}."))
             return
         # TODO: this locates duplicate filenames across dirs, is that right?
         # Difficult to log instances because first is not captured.

--- a/src/ingest_validation_tests/fastq_validator_logic.py
+++ b/src/ingest_validation_tests/fastq_validator_logic.py
@@ -213,7 +213,7 @@ class FASTQValidatorLogic:
             for filename, filepaths in files_per_path.items():
                 if len(filepaths) > 1:
                     self.errors.append(_log(
-                        f"{filename} has been found multiple times during this validation of path {data_path}. Duplicates: {filepaths}."))  # noqa: E501
+                        f"{filename} has been found multiple times during this validation. Locations of duplicates: {filepaths}."))  # noqa: E501
 
     def _find_shared_prefixes(self, lock):
         # This pattern seeks out the string that includes the lane number (since

--- a/src/ingest_validation_tests/gz_validator.py
+++ b/src/ingest_validation_tests/gz_validator.py
@@ -10,22 +10,21 @@ def _log(message: str):
 
 
 class Engine(object):
-    def __call__(self, path_list):
-        for path in path_list:
-            for filename in path.glob('**/*.gz'):
-                excluded = r'.*/*fastq.gz'
-                if re.search(excluded, filename.as_posix()):
-                    return
-                try:
-                    _log(f'Threaded {filename}')
-                    with gzip.open(filename) as g_f:
-                        while True:
-                            buf = g_f.read(1024*1024)
-                            if not buf:
-                                break
-                except Exception as e:
-                    _log(f'{filename} is not a valid gzipped file {e}')
-                    return f'{filename} is not a valid gzipped file'
+    def __call__(self, path):
+        for filename in path.glob('**/*.gz'):
+            excluded = r'.*/*fastq.gz'
+            if re.search(excluded, filename.as_posix()):
+                return
+            try:
+                _log(f'Threaded {filename}')
+                with gzip.open(filename) as g_f:
+                    while True:
+                        buf = g_f.read(1024*1024)
+                        if not buf:
+                            break
+            except Exception as e:
+                _log(f'{filename} is not a valid gzipped file {e}')
+                return f'{filename} is not a valid gzipped file'
 
 
 class GZValidator(Validator):

--- a/src/ingest_validation_tests/gz_validator.py
+++ b/src/ingest_validation_tests/gz_validator.py
@@ -1,6 +1,4 @@
-from os import cpu_count
 import re
-from multiprocessing import Pool
 from typing import List
 
 import gzip
@@ -43,7 +41,7 @@ class GZValidator(Validator):
         except Exception as e:
             _log(f'Error {e}')
         else:
-            pool.close()
-            pool.join()
+            self.pool.close()
+            self.pool.join()
             [data_output2.append(output) for output in data_output if output]
         return data_output2

--- a/src/ingest_validation_tests/gz_validator.py
+++ b/src/ingest_validation_tests/gz_validator.py
@@ -1,3 +1,5 @@
+from multiprocessing import Pool
+from os import cpu_count
 import re
 from typing import List
 
@@ -33,14 +35,16 @@ class GZValidator(Validator):
 
     def collect_errors(self, **kwargs) -> List[str]:
         data_output2 = []
-        _log(f'Threading at {self.threads}')
+        threads = kwargs.get('coreuse', None) or cpu_count() // 4 or 1
+        _log(f'Threading at {threads}')
         try:
+            pool = Pool(threads)
             engine = Engine()
-            data_output = self.pool.imap_unordered(engine, self.paths)
+            data_output = pool.imap_unordered(engine, self.paths)
         except Exception as e:
             _log(f'Error {e}')
         else:
-            self.pool.close()
-            self.pool.join()
+            pool.close()
+            pool.join()
             [data_output2.append(output) for output in data_output if output]
         return data_output2

--- a/src/ingest_validation_tests/gz_validator.py
+++ b/src/ingest_validation_tests/gz_validator.py
@@ -12,21 +12,20 @@ def _log(message: str):
 
 
 class Engine(object):
-    def __call__(self, path):
-        for filename in path.glob('**/*.gz'):
-            excluded = r'.*/*fastq.gz'
-            if re.search(excluded, filename.as_posix()):
-                return
-            try:
-                _log(f'Threaded {filename}')
-                with gzip.open(filename) as g_f:
-                    while True:
-                        buf = g_f.read(1024*1024)
-                        if not buf:
-                            break
-            except Exception as e:
-                _log(f'{filename} is not a valid gzipped file {e}')
-                return f'{filename} is not a valid gzipped file'
+    def __call__(self, filename):
+        excluded = r".*/*fastq.gz"
+        if re.search(excluded, filename.as_posix()):
+            return
+        try:
+            _log(f"Threaded {filename}")
+            with gzip.open(filename) as g_f:
+                while True:
+                    buf = g_f.read(1024 * 1024)
+                    if not buf:
+                        break
+        except Exception as e:
+            _log(f"{filename} is not a valid gzipped file {e}")
+            return f"{filename} is not a valid gzipped file"
 
 
 class GZValidator(Validator):
@@ -35,16 +34,18 @@ class GZValidator(Validator):
 
     def collect_errors(self, **kwargs) -> List[str]:
         data_output2 = []
-        threads = kwargs.get('coreuse', None) or cpu_count() // 4 or 1
-        _log(f'Threading at {threads}')
-        try:
-            pool = Pool(threads)
-            engine = Engine()
-            data_output = pool.imap_unordered(engine, self.paths)
-        except Exception as e:
-            _log(f'Error {e}')
-        else:
-            pool.close()
-            pool.join()
-            [data_output2.append(output) for output in data_output if output]
+        threads = kwargs.get("coreuse", None) or cpu_count() // 4 or 1
+        _log(f"Threading at {threads}")
+        for path in self.paths:
+            for glob_expr in ["**/*.gz"]:
+                try:
+                    pool = Pool(threads)
+                    engine = Engine()
+                    data_output = pool.imap_unordered(engine, path.glob(glob_expr))
+                except Exception as e:
+                    _log(f"Error {e}")
+                else:
+                    pool.close()
+                    pool.join()
+                    [data_output2.append(output) for output in data_output if output]
         return data_output2

--- a/src/ingest_validation_tests/gz_validator.py
+++ b/src/ingest_validation_tests/gz_validator.py
@@ -36,16 +36,18 @@ class GZValidator(Validator):
         data_output2 = []
         threads = kwargs.get("coreuse", None) or cpu_count() // 4 or 1
         _log(f"Threading at {threads}")
+        file_list = []
         for path in self.paths:
             for glob_expr in ["**/*.gz"]:
-                try:
-                    pool = Pool(threads)
-                    engine = Engine()
-                    data_output = pool.imap_unordered(engine, path.glob(glob_expr))
-                except Exception as e:
-                    _log(f"Error {e}")
-                else:
-                    pool.close()
-                    pool.join()
-                    [data_output2.append(output) for output in data_output if output]
+                file_list.extend(path.glob(glob_expr))
+        try:
+            pool = Pool(threads)
+            engine = Engine()
+            data_output = pool.imap_unordered(engine, file_list)
+        except Exception as e:
+            _log(f"Error {e}")
+        else:
+            pool.close()
+            pool.join()
+            [data_output2.append(output) for output in data_output if output]
         return data_output2

--- a/src/ingest_validation_tests/ome_tiff_validator.py
+++ b/src/ingest_validation_tests/ome_tiff_validator.py
@@ -1,23 +1,65 @@
 from typing import List
+from pathlib import Path
 
-import xmlschema
 import tifffile
+import xmlschema
 from ingest_validation_tools.plugin_validator import Validator
 
+
+# def _check_ome_tiff_file(paths: str):
+#     rslt_list = []
+#     for path in paths:
+#         try:
+#             with tifffile.TiffFile(path) as tf:
+#                 xml_document = xmlschema.XmlDocument(tf.ome_metadata)
+#             if not xml_document.schema.is_valid(xml_document):
+#                 return f"{path} is not a valid OME.TIFF file"
+#         except Exception as excp:
+#             rslt_list.append(f"{path} is not a valid OME.TIFF file: {excp}")
+#     return rslt_list
+#
+# def _glob_paths(path: str):
+#     filenames_to_test = []
+#     for glob_expr in ['**/*.ome.tif', '**/*.ome.tiff', '**/*.OME.TIFF', '**/*.OME.TIF']:
+#         for file in path.glob(glob_expr):
+#             filenames_to_test.append(file)
+#     return filenames_to_test
+#
+#
 class OmeTiffValidator(Validator):
     description = "Recursively test all ome-tiff files for validity"
     cost = 1.0
+
     def collect_errors(self, **kwargs) -> List[str]:
+        del kwargs
         rslt = []
         for glob_expr in ['**/*.ome.tif', '**/*.ome.tiff', '**/*.OME.TIFF', '**/*.OME.TIF']:
-            for path in self.path.glob(glob_expr):
-                try:
-                    with tifffile.TiffFile(path) as tf:
-                        xml_document = xmlschema.XmlDocument(tf.ome_metadata)
-                    if not xml_document.schema.is_valid(xml_document):
-                        rslt.append(f'{path} is not a valid OME.TIFF file')
-                except Exception as excp:
-                    rslt.append(f'{path} is not a valid OME.TIFF file: {excp}')
+            for path in self.paths:
+                for file in path.glob(glob_expr):
+                    try:
+                        with tifffile.TiffFile(file) as tf:
+                            xml_document = xmlschema.XmlDocument(tf.ome_metadata)
+                        if not xml_document.schema.is_valid(xml_document):
+                            rslt.append(f'{file} is not a valid OME.TIFF file')
+                    except Exception as excp:
+                        rslt.append(f'{file} is not a valid OME.TIFF file: {excp}')
         return rslt
-
-
+    # def collect_errors(self, **kwargs) -> List[str]:
+    #     del kwargs
+    #     filenames_to_test = list(
+    #         file
+    #         for file in self.pool.imap_unordered(_glob_paths, self.paths)
+    #         if file is not None
+    #     )
+    #     # TODO: this is awful
+    #     return list(
+    #         x
+    #         for y in list(
+    #             rslt
+    #             for rslt in self.pool.imap_unordered(
+    #                 _check_ome_tiff_file, filenames_to_test
+    #             )
+    #             if rslt is not None
+    #         )
+    #         for x in y
+    #     )

--- a/src/ingest_validation_tests/ome_tiff_validator.py
+++ b/src/ingest_validation_tests/ome_tiff_validator.py
@@ -6,26 +6,6 @@ import xmlschema
 from ingest_validation_tools.plugin_validator import Validator
 
 
-# def _check_ome_tiff_file(paths: str):
-#     rslt_list = []
-#     for path in paths:
-#         try:
-#             with tifffile.TiffFile(path) as tf:
-#                 xml_document = xmlschema.XmlDocument(tf.ome_metadata)
-#             if not xml_document.schema.is_valid(xml_document):
-#                 return f"{path} is not a valid OME.TIFF file"
-#         except Exception as excp:
-#             rslt_list.append(f"{path} is not a valid OME.TIFF file: {excp}")
-#     return rslt_list
-#
-# def _glob_paths(path: str):
-#     filenames_to_test = []
-#     for glob_expr in ['**/*.ome.tif', '**/*.ome.tiff', '**/*.OME.TIFF', '**/*.OME.TIF']:
-#         for file in path.glob(glob_expr):
-#             filenames_to_test.append(file)
-#     return filenames_to_test
-#
-#
 class OmeTiffValidator(Validator):
     description = "Recursively test all ome-tiff files for validity"
     cost = 1.0
@@ -44,22 +24,3 @@ class OmeTiffValidator(Validator):
                     except Exception as excp:
                         rslt.append(f'{file} is not a valid OME.TIFF file: {excp}')
         return rslt
-    # def collect_errors(self, **kwargs) -> List[str]:
-    #     del kwargs
-    #     filenames_to_test = list(
-    #         file
-    #         for file in self.pool.imap_unordered(_glob_paths, self.paths)
-    #         if file is not None
-    #     )
-    #     # TODO: this is awful
-    #     return list(
-    #         x
-    #         for y in list(
-    #             rslt
-    #             for rslt in self.pool.imap_unordered(
-    #                 _check_ome_tiff_file, filenames_to_test
-    #             )
-    #             if rslt is not None
-    #         )
-    #         for x in y
-    #     )

--- a/src/ingest_validation_tests/ome_tiff_validator.py
+++ b/src/ingest_validation_tests/ome_tiff_validator.py
@@ -1,5 +1,4 @@
 from typing import List
-from pathlib import Path
 
 import tifffile
 import xmlschema

--- a/src/ingest_validation_tests/ome_tiff_validator.py
+++ b/src/ingest_validation_tests/ome_tiff_validator.py
@@ -1,3 +1,5 @@
+from multiprocessing import Pool
+from os import cpu_count
 from typing import List
 
 import tifffile
@@ -5,21 +7,35 @@ import xmlschema
 from ingest_validation_tools.plugin_validator import Validator
 
 
+def _check_ome_tiff_file(file: str):
+    try:
+        with tifffile.TiffFile(file) as tf:
+            xml_document = xmlschema.XmlDocument(tf.ome_metadata)
+        if xml_document.schema and not xml_document.schema.is_valid(xml_document):
+            return f"{file} is not a valid OME.TIFF file"
+    except Exception as excp:
+        return f"{file} is not a valid OME.TIFF file: {excp}"
+
+
 class OmeTiffValidator(Validator):
     description = "Recursively test all ome-tiff files for validity"
     cost = 1.0
 
     def collect_errors(self, **kwargs) -> List[str]:
-        del kwargs
-        rslt = []
-        for glob_expr in ['**/*.ome.tif', '**/*.ome.tiff', '**/*.OME.TIFF', '**/*.OME.TIF']:
+        threads = kwargs.get("coreuse", None) or cpu_count() // 4 or 1
+        pool = Pool(threads)
+        filenames_to_test = []
+        for glob_expr in [
+            "**/*.ome.tif",
+            "**/*.ome.tiff",
+            "**/*.OME.TIFF",
+            "**/*.OME.TIF",
+        ]:
             for path in self.paths:
                 for file in path.glob(glob_expr):
-                    try:
-                        with tifffile.TiffFile(file) as tf:
-                            xml_document = xmlschema.XmlDocument(tf.ome_metadata)
-                        if not xml_document.schema.is_valid(xml_document):
-                            rslt.append(f'{file} is not a valid OME.TIFF file')
-                    except Exception as excp:
-                        rslt.append(f'{file} is not a valid OME.TIFF file: {excp}')
-        return rslt
+                    filenames_to_test.append(file)
+        return list(
+            rslt
+            for rslt in pool.imap_unordered(_check_ome_tiff_file, filenames_to_test)
+            if rslt is not None
+        )

--- a/src/ingest_validation_tests/tiff_validator.py
+++ b/src/ingest_validation_tests/tiff_validator.py
@@ -1,6 +1,6 @@
 from multiprocessing import Pool
 from os import cpu_count
-from typing import List
+from typing import List, Optional
 
 import tifffile
 from ingest_validation_tools.plugin_validator import Validator
@@ -21,7 +21,7 @@ def _log(message: str):
     print(message)
 
 
-def _check_tiff_file(path: str) -> str or None:
+def _check_tiff_file(path: str) -> Optional[str]:
     try:
         with tifffile.TiffFile(path) as tfile:
             for page in tfile.pages:

--- a/src/ingest_validation_tests/tiff_validator.py
+++ b/src/ingest_validation_tests/tiff_validator.py
@@ -40,7 +40,6 @@ class TiffValidator(Validator):
         threads = kwargs.get('coreuse', None) or cpu_count() // 4 or 1
         pool = Pool(threads)
         filenames_to_test = []
-        # TODO: this does not exclude OME.TIFF files, should it?
         for glob_expr in ['**/*.tif', '**/*.tiff', '**/*.TIFF', '**/*.TIF']:
             for path in self.paths:
                 for file in path.glob(glob_expr):

--- a/src/ingest_validation_tests/tiff_validator.py
+++ b/src/ingest_validation_tests/tiff_validator.py
@@ -1,7 +1,6 @@
 from multiprocessing import Pool
 from os import cpu_count
-from pathlib import Path
-from typing import List, Optional
+from typing import List
 
 import tifffile
 from ingest_validation_tools.plugin_validator import Validator
@@ -41,6 +40,7 @@ class TiffValidator(Validator):
         threads = kwargs.get('coreuse', None) or cpu_count() // 4 or 1
         pool = Pool(threads)
         filenames_to_test = []
+        # TODO: this does not exclude OME.TIFF files, should it?
         for glob_expr in ['**/*.tif', '**/*.tiff', '**/*.TIFF', '**/*.TIF']:
             for path in self.paths:
                 for file in path.glob(glob_expr):

--- a/src/ingest_validation_tests/tiff_validator.py
+++ b/src/ingest_validation_tests/tiff_validator.py
@@ -33,59 +33,18 @@ def _check_tiff_file(path: str) -> str or None:
         return f"{path} is not a valid TIFF file: {excp}"
 
 
-# def _check_tiff_file(paths: List) -> Optional[str]:
-#     rslt_list = []
-#     for path in paths:
-#         try:
-#             with tifffile.TiffFile(path) as tfile:
-#                 for page in tfile.pages:
-#                     _ = page.asarray()  # force decompression
-#             return None
-#         except Exception as excp:
-#             _log(f"{str(path)} is not a valid TIFF file: {excp}")
-#             rslt_list.append(f"{path} is not a valid TIFF file: {excp}")
-#     return rslt_list
-#
-
-
-# def _glob_paths(path: str):
-#     filenames_to_test = []
-#     for glob_expr in ["**/*.tif", "**/*.tiff", "**/*.TIFF", "**/*.TIF"]:
-#         for file in path.glob(glob_expr):
-#             filenames_to_test.append(file)
-#     return filenames_to_test
-
-
 class TiffValidator(Validator):
     description = "Recursively test all tiff files that are not ome.tiffs for validity"
     cost = 1.0
 
     def collect_errors(self, **kwargs) -> List[str]:
-        del kwargs
+        threads = kwargs.get('coreuse', None) or cpu_count() // 4 or 1
+        pool = Pool(threads)
         filenames_to_test = []
-        for glob_expr in ["**/*.tif", "**/*.tiff", "**/*.TIFF", "**/*.TIF"]:
+        for glob_expr in ['**/*.tif', '**/*.tiff', '**/*.TIFF', '**/*.TIF']:
             for path in self.paths:
                 for file in path.glob(glob_expr):
                     filenames_to_test.append(file)
-        return list(
-            rslt
-            for rslt in self.pool.imap_unordered(_check_tiff_file, filenames_to_test)
-            if rslt is not None
-        )
-        # filenames_to_test = list(
-        #     file
-        #     for file in self.pool.imap_unordered(_glob_paths, self.paths)
-        #     if file is not None
-        # )
-        # # TODO: this is awful
-        # return list(
-        #     x
-        #     for y in list(
-        #         rslt
-        #         for rslt in self.pool.imap_unordered(
-        #             _check_tiff_file, filenames_to_test
-        #         )
-        #         if rslt is not None
-        #     )
-        #     for x in y
-        # )
+        return list(rslt for rslt in pool.imap_unordered(_check_tiff_file,
+                                                              filenames_to_test)
+            if rslt is not None)

--- a/src/ingest_validation_tests/tiff_validator.py
+++ b/src/ingest_validation_tests/tiff_validator.py
@@ -1,6 +1,7 @@
-from os import cpu_count
 from multiprocessing import Pool
-from typing import List
+from os import cpu_count
+from pathlib import Path
+from typing import List, Optional
 
 import tifffile
 from ingest_validation_tools.plugin_validator import Validator
@@ -8,8 +9,12 @@ from ingest_validation_tools.plugin_validator import Validator
 # monkey patch tifffile to raise an exception every time a warning
 # is logged
 original_log_warning = tifffile.tifffile.log_warning
+
+
 def my_log_warning(msg, *args, **kwargs):
     raise RuntimeError(f"{msg.format(*args, **kwargs)}")
+
+
 tifffile.tifffile.log_warning = my_log_warning
 
 
@@ -28,16 +33,59 @@ def _check_tiff_file(path: str) -> str or None:
         return f"{path} is not a valid TIFF file: {excp}"
 
 
+# def _check_tiff_file(paths: List) -> Optional[str]:
+#     rslt_list = []
+#     for path in paths:
+#         try:
+#             with tifffile.TiffFile(path) as tfile:
+#                 for page in tfile.pages:
+#                     _ = page.asarray()  # force decompression
+#             return None
+#         except Exception as excp:
+#             _log(f"{str(path)} is not a valid TIFF file: {excp}")
+#             rslt_list.append(f"{path} is not a valid TIFF file: {excp}")
+#     return rslt_list
+#
+
+
+# def _glob_paths(path: str):
+#     filenames_to_test = []
+#     for glob_expr in ["**/*.tif", "**/*.tiff", "**/*.TIFF", "**/*.TIF"]:
+#         for file in path.glob(glob_expr):
+#             filenames_to_test.append(file)
+#     return filenames_to_test
+
+
 class TiffValidator(Validator):
     description = "Recursively test all tiff files that are not ome.tiffs for validity"
     cost = 1.0
+
     def collect_errors(self, **kwargs) -> List[str]:
-        threads = kwargs.get('coreuse', None) or cpu_count() // 4 or 1
-        pool = Pool(threads)
+        del kwargs
         filenames_to_test = []
-        for glob_expr in ['**/*.tif', '**/*.tiff', '**/*.TIFF', '**/*.TIF']:
-            for path in self.path.glob(glob_expr):
-                filenames_to_test.append(path)
-        return list(rslt for rslt in pool.imap_unordered(_check_tiff_file,
-                                                         filenames_to_test)
-                    if rslt is not None)
+        for glob_expr in ["**/*.tif", "**/*.tiff", "**/*.TIFF", "**/*.TIF"]:
+            for path in self.paths:
+                for file in path.glob(glob_expr):
+                    filenames_to_test.append(file)
+        return list(
+            rslt
+            for rslt in self.pool.imap_unordered(_check_tiff_file, filenames_to_test)
+            if rslt is not None
+        )
+        # filenames_to_test = list(
+        #     file
+        #     for file in self.pool.imap_unordered(_glob_paths, self.paths)
+        #     if file is not None
+        # )
+        # # TODO: this is awful
+        # return list(
+        #     x
+        #     for y in list(
+        #         rslt
+        #         for rslt in self.pool.imap_unordered(
+        #             _check_tiff_file, filenames_to_test
+        #         )
+        #         if rslt is not None
+        #     )
+        #     for x in y
+        # )

--- a/tests/test_codex_common_errors_validator.py
+++ b/tests/test_codex_common_errors_validator.py
@@ -40,7 +40,7 @@ def test_codex_common_errors_validator(test_data_fname, msg_starts_list, tmp_pat
     test_data_path = Path(test_data_fname)
     zfile = zipfile.ZipFile(test_data_path)
     zfile.extractall(tmp_path)
-    validator = CodexCommonErrorsValidator(tmp_path / test_data_path.stem,
+    validator = CodexCommonErrorsValidator([Path(tmp_path / test_data_path.stem)],
                                            'CODEX'
                                            )
     errors = validator.collect_errors()[:]

--- a/tests/test_fastq_validator_logic.py
+++ b/tests/test_fastq_validator_logic.py
@@ -39,7 +39,7 @@ class TestFASTQValidatorLogic:
         return FASTQValidatorLogic()
 
     def test_fastq_validator_no_files(self, fastq_validator, tmp_path):
-        fastq_validator.validate_fastq_files_in_path(tmp_path, 2)
+        fastq_validator.validate_fastq_files_in_path([tmp_path], 2)
         # This case should return no errors
         assert fastq_validator.errors == []
 
@@ -65,7 +65,7 @@ class TestFASTQValidatorLogic:
 
     def test_fastq_validator_empty_directory(self, fastq_validator,
                                              tmp_path):
-        fastq_validator.validate_fastq_files_in_path(tmp_path, 2)
+        fastq_validator.validate_fastq_files_in_path([tmp_path], 2)
         # No files in path means no errors
         assert fastq_validator.errors == []
 
@@ -76,7 +76,7 @@ class TestFASTQValidatorLogic:
         with _open_output_file(test_file, use_gzip) as output:
             output.write(_GOOD_RECORDS)
 
-        fastq_validator.validate_fastq_files_in_path(tmp_path, 2)
+        fastq_validator.validate_fastq_files_in_path([tmp_path], 2)
         assert not fastq_validator.errors
 
     def test_fastq_validator_bad_file(self, fastq_validator, tmp_path):
@@ -84,7 +84,7 @@ class TestFASTQValidatorLogic:
         with _open_output_file(test_file, False) as output:
             output.write('ABCDEF')
 
-        fastq_validator.validate_fastq_files_in_path(tmp_path, 2)
+        fastq_validator.validate_fastq_files_in_path([tmp_path], 2)
 
         # This test does not assert specific validations but instead that the
         # overall file failed and that error messages were returned.
@@ -98,7 +98,7 @@ class TestFASTQValidatorLogic:
                                    False) as output:
                 output.write(_GOOD_RECORDS)
 
-        fastq_validator.validate_fastq_files_in_path(tmp_path, 2)
+        fastq_validator.validate_fastq_files_in_path([tmp_path], 2)
         assert "test.fastq has been found multiple times" in \
                fastq_validator.errors[0]
 
@@ -192,7 +192,7 @@ NACTGACTGA
             with _open_output_file(new_file, False) as output:
                 output.write(_GOOD_RECORDS)
 
-        fastq_validator.validate_fastq_files_in_path(tmp_path, 2)
+        fastq_validator.validate_fastq_files_in_path([tmp_path], 2)
 
         assert not fastq_validator.errors
 
@@ -208,7 +208,7 @@ NACTGACTGA
             output.write(_GOOD_RECORDS)
             output.write(_GOOD_RECORDS)
 
-        fastq_validator.validate_fastq_files_in_path(tmp_path, 2)
+        fastq_validator.validate_fastq_files_in_path([tmp_path], 2)
 
         # Order of the files being processed is not guaranteed, however these
         # strings ensure that a mismatch was found.

--- a/tests/test_fastq_validator_logic.py
+++ b/tests/test_fastq_validator_logic.py
@@ -51,7 +51,7 @@ class TestFASTQValidatorLogic:
             output.write(_GOOD_RECORDS)
 
         fastq_validator.validate_fastq_file(test_file, Lock())
-        assert "Unable to open" in fastq_validator.errors[0]
+        assert "Bad gzip file" in fastq_validator.errors[0]
 
     def test_fastq_validator_unrecognized_file(self, fastq_validator,
                                                tmp_path):

--- a/tests/test_fastq_validator_logic.py
+++ b/tests/test_fastq_validator_logic.py
@@ -50,7 +50,7 @@ class TestFASTQValidatorLogic:
         with _open_output_file(test_file, False) as output:
             output.write(_GOOD_RECORDS)
 
-        fastq_validator.validate_fastq_file(test_file, Lock())
+        fastq_validator.validate_fastq_file(test_file)
         assert "Bad gzip file" in fastq_validator.errors[0]
 
     def test_fastq_validator_unrecognized_file(self, fastq_validator,
@@ -59,7 +59,7 @@ class TestFASTQValidatorLogic:
         with _open_output_file(test_file, False) as output:
             output.write(_GOOD_RECORDS)
 
-        fastq_validator.validate_fastq_file(test_file, Lock())
+        fastq_validator.validate_fastq_file(test_file)
         assert "Filename does not have proper format" in \
                fastq_validator.errors[0]
 
@@ -105,7 +105,7 @@ class TestFASTQValidatorLogic:
     def test_fastq_validator_io_error(self, fastq_validator, tmp_path):
         fake_path = tmp_path.joinpath('does-not-exist.fastq')
 
-        fastq_validator.validate_fastq_file(fake_path, Lock())
+        fastq_validator.validate_fastq_file(fake_path)
 
         assert "Unable to open" in fastq_validator.errors[0]
 
@@ -178,7 +178,7 @@ NACTGACTGA
         with _open_output_file(new_file, False) as output:
             output.write(test_data)
 
-        fastq_validator.validate_fastq_file(new_file, Lock())
+        fastq_validator.validate_fastq_file(new_file)
         assert "contains 9 characters which does not match line 2's 10" in \
                fastq_validator.errors[0]
 


### PR DESCRIPTION
Validator parent class (in IVT) accepts a list of data_paths rather than a single path at a time. Files are then collected and processed in parallel in various plugin subclasses. Testing indicates that this cuts processing time of fastq files in half (at least for a <10GB upload with fastq files). EDIT: or maybe way less!

CODEX and Publication plugins accept data_path lists but are not currently parallelized, but can be updated to be. Testing for these plugins is already quite fast so I focused on large-file plugins (fasq, gz, ome.tiff, tiff).

Parallelizing made redundancy checking in fastq_validator_logic unreliable. I moved this logic outside of the Engine call that processes files in parallel.

Tested:
- Tests in repo work (locally). 
     - Tests include TIFFs, which take the most time. Previous testing time: 22.38s. New testing time: 14.11s.
- Large valid 10x upload ([on DEV](https://vm001.hive.psc.edu:5555/dags/validate_upload/grid?dag_run_id=4220f95e9110922370afa25193f6becb_validate.upload_2024-01-26T10%3A30%3A39.127130-05%3A00)).
- Upload with intentional duplicated fastq file--caught properly both by prefix and duplicate checking.
- Tested from the IVT side as well.

## Note
- Checks failing because a change to IVT is also required.