### PR TITLE
FASTQ plugin fix

### DIFF
--- a/src/ingest_validation_tests/fastq_validator.py
+++ b/src/ingest_validation_tests/fastq_validator.py
@@ -14,7 +14,7 @@ class FASTQValidator(Validator):
         threads = kwargs.get("coreuse", None) or cpu_count() // 4 or 1
         _log(f"Threading at FastQValidator with {threads}")
         validator = FASTQValidatorLogic(verbose=True)
-        validator.validate_fastq_files_in_path(self.paths, self.thread_count)
+        validator.validate_fastq_files_in_path(self.paths, threads)
         if validator.errors:
             return validator.errors
         elif validator.files_were_found:

--- a/src/ingest_validation_tests/fastq_validator.py
+++ b/src/ingest_validation_tests/fastq_validator.py
@@ -8,9 +8,13 @@ class FASTQValidator(Validator):
     description = "Check FASTQ files for basic syntax and consistency."
     cost = 15.0
     version = "1.0"
+    # need to add to parent validator class in IVT, hack for now
+    thread_count = None
 
     def collect_errors(self, **kwargs) -> List[Optional[str]]:
         del kwargs
+        if not self.thread_count:
+            self.thread_count = 1
         _log(f"Threading at FastQValidator with {self.thread_count}")
         validator = FASTQValidatorLogic(verbose=True)
         validator.validate_fastq_files_in_path(self.paths, self.thread_count)

--- a/src/ingest_validation_tests/fastq_validator.py
+++ b/src/ingest_validation_tests/fastq_validator.py
@@ -1,4 +1,3 @@
-from os import cpu_count
 from typing import List, Optional
 
 from fastq_validator_logic import FASTQValidatorLogic, _log
@@ -11,10 +10,10 @@ class FASTQValidator(Validator):
     version = "1.0"
 
     def collect_errors(self, **kwargs) -> List[Optional[str]]:
-        threads = kwargs.get("coreuse", None) or cpu_count() // 4 or 1
-        _log(f"Threading at FastQValidator with {threads}")
+        del kwargs
+        _log(f"Threading at FastQValidator with {self.thread_count}")
         validator = FASTQValidatorLogic(verbose=True)
-        validator.validate_fastq_files_in_path(self.paths, threads)
+        validator.validate_fastq_files_in_path(self.paths, self.thread_count)
         if validator.errors:
             return validator.errors
         elif validator.files_were_found:

--- a/src/ingest_validation_tests/fastq_validator.py
+++ b/src/ingest_validation_tests/fastq_validator.py
@@ -1,3 +1,4 @@
+from os import cpu_count
 from typing import List, Optional
 
 from fastq_validator_logic import FASTQValidatorLogic, _log
@@ -8,14 +9,10 @@ class FASTQValidator(Validator):
     description = "Check FASTQ files for basic syntax and consistency."
     cost = 15.0
     version = "1.0"
-    # need to add to parent validator class in IVT, hack for now
-    thread_count = None
 
     def collect_errors(self, **kwargs) -> List[Optional[str]]:
-        del kwargs
-        if not self.thread_count:
-            self.thread_count = 1
-        _log(f"Threading at FastQValidator with {self.thread_count}")
+        threads = kwargs.get("coreuse", None) or cpu_count() // 4 or 1
+        _log(f"Threading at FastQValidator with {threads}")
         validator = FASTQValidatorLogic(verbose=True)
         validator.validate_fastq_files_in_path(self.paths, self.thread_count)
         if validator.errors:

--- a/src/ingest_validation_tests/fastq_validator_logic.py
+++ b/src/ingest_validation_tests/fastq_validator_logic.py
@@ -21,20 +21,24 @@ def is_valid_filename(filename: str) -> bool:
 
 def get_prefix_read_type_and_set(filename: str) -> Optional[filename_pattern]:
     """
-    PREFIX (?P<prefix>.*(?:L\\d+)
-        - (?P<prefix> | named capture group "prefix"
-        - .*(?:L\\d+) | match anything before pattern L# (where # represents 1 or more digits)
-        - only capture if read_type found
-    READ_TYPE
-        - (?=_ | assert that the character "_" is present at the beginning of this next group
-        - (?:(?P<read_type>R|read(?=[123])|I(?=[12]))) | only capture above match if followed by the sequence _[R1,R2,R3,read1,read2,read3,I1,I2]; capture R/I/read as read_type
-    SET_NUM
-        - (?:\\d_ | ensure presence of "#_" before group, ignore characters
-        - (?P<set_num>\\d+) | capture group set_num of 1 or more digits
+    Regex explanation:
+        PREFIX
+            - (?P<prefix> | named capture group "prefix"
+            - .*(?:L\\d+) | match anything before pattern L# (where # represents 1 or more digits)
+            - only capture if read_type and set_num found
+        READ_TYPE
+            - (?=_ | assert that the character "_" is present at the beginning of this next group
+            - (?:(?P<read_type>R|read(?=[123])|I(?=[12]))) | only capture above match if followed by the sequence _[R1,R2,R3,read1,read2,read3,I1,I2]; capture R/I/read as read_type
+        SET_NUM
+            - (?:\\d_ | ensure presence of "#_" before group, ignore characters
+            - (?P<set_num>\\d+) | capture group set_num of 1 or more digits
+               Note: if set_num needs to be optional, could change this portion to (?:\\d_?(?P<set_num>\\d+)|)
     """
     if not bool(fastq_utils.FASTQ_PATTERN.fullmatch(filename)):
+        # looking for fastq filenames matching pattern
+        # <prefix>_<lane:L#+>_<read_type:I,R,read>#_<set_num:#+>
+        # e.g. arbitrary_string_L001_R1_001.fastq
         return
-    # looking for fastq filenames matching pattern <prefix>_<lane>_[I1,I2,R1,R2,R3]_<set_num>
     pattern = re.compile(
         r"(?P<prefix>.*(?:L\d+)(?=_(?P<read_type>R|read(?=[123])|I(?=[12]))(?:\d_(?P<set_num>\d+))))"
     )

--- a/src/ingest_validation_tests/fastq_validator_logic.py
+++ b/src/ingest_validation_tests/fastq_validator_logic.py
@@ -21,17 +21,22 @@ def is_valid_filename(filename: str) -> bool:
 
 def get_prefix_read_type_and_set(filename: str) -> Optional[filename_pattern]:
     """
-    PREFIX (?P<prefix>.*(?:L\\d+)(?=[_](?:(?P<read_type>(?:R|read)(?=[123])|I(?=[12])))))
+    PREFIX (?P<prefix>.*(?:L\\d+)
         - (?P<prefix> | named capture group "prefix"
         - .*(?:L\\d+) | match anything before pattern L# (where # represents 1 or more digits)
-        - (?=[_](?:(?P<read_type>(?:R|read)(?=[123])|I(?=[12])))) | only capture above match if followed by the sequence _[R1,R2,R3,read1,read2,read3,I1,I2]
-
+        - only capture if read_type found
+    READ_TYPE
+        - (?=_ | assert that the character "_" is present at the beginning of this next group
+        - (?:(?P<read_type>R|read(?=[123])|I(?=[12]))) | only capture above match if followed by the sequence _[R1,R2,R3,read1,read2,read3,I1,I2]; capture R/I/read as read_type
+    SET_NUM
+        - (?:\\d_ | ensure presence of "#_" before group, ignore characters
+        - (?P<set_num>\\d+) | capture group set_num of 1 or more digits
     """
     if not bool(fastq_utils.FASTQ_PATTERN.fullmatch(filename)):
         return
     # looking for fastq filenames matching pattern <prefix>_<lane>_[I1,I2,R1,R2,R3]_<set_num>
     pattern = re.compile(
-        r"(?P<prefix>.*(?:L\d+)(?=[_](?:(?P<read_type>(?:R|read)(?=[123])|I(?=[12]))(?:\d?_)(?P<set_num>\d+))))"
+        r"(?P<prefix>.*(?:L\d+)(?=_(?P<read_type>R|read(?=[123])|I(?=[12]))(?:\d_(?P<set_num>\d+))))"
     )
     groups = pattern.match(filename)
     if groups and all(x in groups.groupdict().keys() for x in ["prefix", "read_type", "set_num"]):
@@ -253,9 +258,9 @@ class FASTQValidatorLogic:
                 pool.close()
                 pool.join()
                 groups = self._make_groups()
+                self._find_counts(groups, lock)
                 if self._ungrouped_files:
                     _log(f"Ungrouped files, counts not checked: {self._ungrouped_files}")
-                self._find_counts(groups, lock)
 
     def _find_duplicates(self) -> None:
         """
@@ -277,6 +282,12 @@ class FASTQValidatorLogic:
     def _find_counts(self, groups: dict[filename_pattern, list[Path]], lock):
         with lock:
             for pattern, paths in groups.items():
+                if len(paths) == 1:
+                    # This would happen if there was a file that matched the prefix_read_set pattern
+                    # but did not have a counterpart for comparison; this probably should not happen but
+                    # is currently only logged and does not throw an exception
+                    self._ungrouped_files.append(paths[0])
+                    continue
                 comparison = {}
                 for path in paths:
                     comparison[str(path)] = self._file_record_counts.get(str(path))

--- a/src/ingest_validation_tests/fastq_validator_logic.py
+++ b/src/ingest_validation_tests/fastq_validator_logic.py
@@ -29,14 +29,14 @@ def get_prefix_read_type_and_set(filename: str) -> Optional[filename_pattern]:
     """
     if not bool(fastq_utils.FASTQ_PATTERN.fullmatch(filename)):
         return
-    # looking for fastq filenames matching pattern <prefix>_<lane>_[I1,I2,R1,R2,R3]_<set>
+    # looking for fastq filenames matching pattern <prefix>_<lane>_[I1,I2,R1,R2,R3]_<set_num>
     pattern = re.compile(
-        r"(?P<prefix>.*(?:L\d+)(?=[_](?:(?P<read_type>(?:R|read)(?=[123]_)|I(?=[12]_)))))"
+        r"(?P<prefix>.*(?:L\d+)(?=[_](?:(?P<read_type>(?:R|read)(?=[123])|I(?=[12]))(?:\d?_)(?P<set_num>\d+))))"
     )
     groups = pattern.match(filename)
-    if groups and all(x in groups.groupdict().keys() for x in ["prefix", "read_type", "set"]):
+    if groups and all(x in groups.groupdict().keys() for x in ["prefix", "read_type", "set_num"]):
         return filename_pattern(
-            groups.group("prefix"), groups.group("read_type"), groups.group("set")
+            groups.group("prefix"), groups.group("read_type"), groups.group("set_num")
         )
 
 

--- a/tests/test_fastq_validator_logic.py
+++ b/tests/test_fastq_validator_logic.py
@@ -202,3 +202,94 @@ NACTGACTGA
         assert "(4 lines)" in fastq_validator.errors[0]
         assert "does not match" in fastq_validator.errors[0]
         assert "(8 lines)" in fastq_validator.errors[0]
+
+    def test_fastq_comparison_good(self, fastq_validator, tmp_path):
+        filenames = [
+            "3252_ftL_RNA_T1_S31_L003_R1_001.fastq",
+            "3252_ftL_RNA_T1_S31_L003_R2_001.fastq",
+            "3252_ftL_RNA_T1_S31_L003_R1_002.fastq",
+            "3252_ftL_RNA_T1_S31_L003_R2_002.fastq",
+        ]
+        for filename in filenames:
+            new_file = tmp_path.joinpath(filename)
+            with _open_output_file(new_file, False) as output:
+                output.write(_GOOD_RECORDS)
+
+        fastq_validator.validate_fastq_files_in_path([tmp_path], 2)
+
+        assert not fastq_validator.errors
+
+    # def test_fastq_comparison_bad_extra_R(self, fastq_validator, tmp_path):
+    #     filenames = [
+    #         "3252_ftL_RNA_T1_S31_L003_R1_001.fastq",
+    #         "3252_ftL_RNA_T1_S31_L003_R2_001.fastq",
+    #         "3252_ftL_RNA_T1_S31_L003_R1_002.fastq",
+    #         "3252_ftL_RNA_T1_S31_L003_R2_002.fastq",
+    #         "3252_ftL_RNA_T1_S31_L003_R3_001.fastq",
+    #     ]
+    #     for filename in filenames:
+    #         new_file = tmp_path.joinpath(filename)
+    #         with _open_output_file(new_file, False) as output:
+    #             output.write(_GOOD_RECORDS)
+    #
+    #     fastq_validator.validate_fastq_files_in_path([tmp_path], 2)
+    #     assert "IndexError: list index out of range" in fastq_validator.errors[0]
+
+    # def test_fastq_comparison_bad_unpaired_R(self, fastq_validator, tmp_path):
+    #     filenames = [
+    #         "3252_ftL_RNA_T1_S31_L003_R1_001.fastq",
+    #         "3252_ftL_RNA_T1_S31_L003_R2_001.fastq",
+    #         "3252_ftL_RNA_T1_S31_L003_R1_002.fastq",
+    #     ]
+    #     for filename in filenames:
+    #         new_file = tmp_path.joinpath(filename)
+    #         with _open_output_file(new_file, False) as output:
+    #             output.write(_GOOD_RECORDS)
+    #
+    #     fastq_validator.validate_fastq_files_in_path([tmp_path], 2)
+    #
+    #     assert fastq_validator.errors
+    #
+    # def test_fastq_comparison_bad_mixed_I_and_R(self, fastq_validator, tmp_path):
+    #     filenames = [
+    #         "3252_ftL_RNA_T1_S31_L003_R1_001.fastq",
+    #         "3252_ftL_RNA_T1_S31_L003_R2_001.fastq",
+    #         "3252_ftL_RNA_T1_S31_L003_I1_002.fastq",
+    #     ]
+    #     for filename in filenames:
+    #         new_file = tmp_path.joinpath(filename)
+    #         with _open_output_file(new_file, False) as output:
+    #             output.write(_GOOD_RECORDS)
+    #
+    #     fastq_validator.validate_fastq_files_in_path([tmp_path], 2)
+    #
+    #     assert fastq_validator.errors
+    #
+    # def test_fastq_comparison_bad_extra_unmatched_fastq(self, fastq_validator, tmp_path):
+    #     filenames = [
+    #         "3252_ftL_RNA_T1_S31_L003_R1_001.fastq",
+    #         "3252_ftL_RNA_T1_S31_L003_R2_001.fastq",
+    #         "bad_ftL_RNA_T1_S31_L003_R1_001.fastq",
+    #     ]
+    #     for filename in filenames:
+    #         new_file = tmp_path.joinpath(filename)
+    #         with _open_output_file(new_file, False) as output:
+    #             output.write(_GOOD_RECORDS)
+    #
+    #     fastq_validator.validate_fastq_files_in_path([tmp_path], 2)
+    #
+    #     assert fastq_validator.errors
+
+    def test_fastq_comparison_bad_unequal_line_counts(self, fastq_validator, tmp_path):
+        good_file = "3252_ftL_RNA_T1_S31_L003_R1_001.fastq"
+        bad_file = "3252_ftL_RNA_T1_S31_L003_R2_001.fastq"
+        new_good_file = tmp_path.joinpath(good_file)
+        with _open_output_file(new_good_file, False) as output:
+            output.write(_GOOD_RECORDS)
+        new_bad_file = tmp_path.joinpath(bad_file)
+        with _open_output_file(new_bad_file, False) as output:
+            output.write("bad")
+
+        fastq_validator.validate_fastq_files_in_path([tmp_path], 2)
+
+        assert fastq_validator.errors

--- a/tests/test_fastq_validator_logic.py
+++ b/tests/test_fastq_validator_logic.py
@@ -1,4 +1,5 @@
 import gzip
+from operator import attrgetter
 from pathlib import Path, PosixPath
 from typing import TextIO
 
@@ -324,14 +325,25 @@ NACTGACTGA
             for file in fastq_validator.file_list
             if get_prefix_read_type_and_set(str(file)) is not None
         ]
-        assert valid_filename_patterns == [
-            filename_pattern(prefix=f"{tmp_path}/H4L1-4_S64_L001", read_type="R", set_num="001"),
-            filename_pattern(prefix=f"{tmp_path}/H4L1-4_S64_L001", read_type="R", set_num="001"),
-            filename_pattern(prefix=f"{tmp_path}/H4L1-4_S64_L001", read_type="I", set_num="001"),
-            filename_pattern(
-                prefix=f"{tmp_path}/Undetermined_S0_L001", read_type="R", set_num="001"
-            ),
-        ]
+        assert sorted(
+            valid_filename_patterns, key=attrgetter("prefix", "read_type", "set_num")
+        ) == sorted(
+            [
+                filename_pattern(
+                    prefix=f"{tmp_path}/H4L1-4_S64_L001", read_type="R", set_num="001"
+                ),
+                filename_pattern(
+                    prefix=f"{tmp_path}/H4L1-4_S64_L001", read_type="R", set_num="001"
+                ),
+                filename_pattern(
+                    prefix=f"{tmp_path}/H4L1-4_S64_L001", read_type="I", set_num="001"
+                ),
+                filename_pattern(
+                    prefix=f"{tmp_path}/Undetermined_S0_L001", read_type="R", set_num="001"
+                ),
+            ],
+            key=attrgetter("prefix", "read_type", "set_num"),
+        )
         assert (
             fastq_validator._ungrouped_files.sort()
             == [

--- a/tests/test_fastq_validator_logic.py
+++ b/tests/test_fastq_validator_logic.py
@@ -1,10 +1,15 @@
 import gzip
-from pathlib import Path
+from pathlib import Path, PosixPath
 from typing import TextIO
 
+import fastq_utils
 import pytest
 
-from src.ingest_validation_tests.fastq_validator_logic import FASTQValidatorLogic
+from src.ingest_validation_tests.fastq_validator_logic import (
+    FASTQValidatorLogic,
+    filename_pattern,
+    get_prefix_read_type_and_set,
+)
 
 _GOOD_RECORDS = """\
 @A12345:123:A12BCDEFG:1:1234:1000:1234 1:N:0:NACTGACTGA+CTGACTGACT
@@ -197,11 +202,14 @@ NACTGACTGA
 
         fastq_validator.validate_fastq_files_in_path([tmp_path], 2)
 
-        # Order of the files being processed is not guaranteed, however these
-        # strings ensure that a mismatch was found.
-        assert "(4 lines)" in fastq_validator.errors[0]
-        assert "does not match" in fastq_validator.errors[0]
-        assert "(8 lines)" in fastq_validator.errors[0]
+        # Non-matching records only stored in errors, need to do ugly string match
+        assert "Counts do not match" in fastq_validator.errors[0]
+        assert (
+            "SREQ-1_1-ACTGACTGAC-TGACTGACTG_S1_L001_I1_001.fastq': 4" in fastq_validator.errors[0]
+        )
+        assert (
+            "SREQ-1_1-ACTGACTGAC-TGACTGACTG_S1_L001_I2_001.fastq': 8" in fastq_validator.errors[0]
+        )
 
     def test_fastq_comparison_good(self, fastq_validator, tmp_path):
         filenames = [
@@ -219,67 +227,6 @@ NACTGACTGA
 
         assert not fastq_validator.errors
 
-    # def test_fastq_comparison_bad_extra_R(self, fastq_validator, tmp_path):
-    #     filenames = [
-    #         "3252_ftL_RNA_T1_S31_L003_R1_001.fastq",
-    #         "3252_ftL_RNA_T1_S31_L003_R2_001.fastq",
-    #         "3252_ftL_RNA_T1_S31_L003_R1_002.fastq",
-    #         "3252_ftL_RNA_T1_S31_L003_R2_002.fastq",
-    #         "3252_ftL_RNA_T1_S31_L003_R3_001.fastq",
-    #     ]
-    #     for filename in filenames:
-    #         new_file = tmp_path.joinpath(filename)
-    #         with _open_output_file(new_file, False) as output:
-    #             output.write(_GOOD_RECORDS)
-    #
-    #     fastq_validator.validate_fastq_files_in_path([tmp_path], 2)
-    #     assert "IndexError: list index out of range" in fastq_validator.errors[0]
-
-    # def test_fastq_comparison_bad_unpaired_R(self, fastq_validator, tmp_path):
-    #     filenames = [
-    #         "3252_ftL_RNA_T1_S31_L003_R1_001.fastq",
-    #         "3252_ftL_RNA_T1_S31_L003_R2_001.fastq",
-    #         "3252_ftL_RNA_T1_S31_L003_R1_002.fastq",
-    #     ]
-    #     for filename in filenames:
-    #         new_file = tmp_path.joinpath(filename)
-    #         with _open_output_file(new_file, False) as output:
-    #             output.write(_GOOD_RECORDS)
-    #
-    #     fastq_validator.validate_fastq_files_in_path([tmp_path], 2)
-    #
-    #     assert fastq_validator.errors
-    #
-    # def test_fastq_comparison_bad_mixed_I_and_R(self, fastq_validator, tmp_path):
-    #     filenames = [
-    #         "3252_ftL_RNA_T1_S31_L003_R1_001.fastq",
-    #         "3252_ftL_RNA_T1_S31_L003_R2_001.fastq",
-    #         "3252_ftL_RNA_T1_S31_L003_I1_002.fastq",
-    #     ]
-    #     for filename in filenames:
-    #         new_file = tmp_path.joinpath(filename)
-    #         with _open_output_file(new_file, False) as output:
-    #             output.write(_GOOD_RECORDS)
-    #
-    #     fastq_validator.validate_fastq_files_in_path([tmp_path], 2)
-    #
-    #     assert fastq_validator.errors
-    #
-    # def test_fastq_comparison_bad_extra_unmatched_fastq(self, fastq_validator, tmp_path):
-    #     filenames = [
-    #         "3252_ftL_RNA_T1_S31_L003_R1_001.fastq",
-    #         "3252_ftL_RNA_T1_S31_L003_R2_001.fastq",
-    #         "bad_ftL_RNA_T1_S31_L003_R1_001.fastq",
-    #     ]
-    #     for filename in filenames:
-    #         new_file = tmp_path.joinpath(filename)
-    #         with _open_output_file(new_file, False) as output:
-    #             output.write(_GOOD_RECORDS)
-    #
-    #     fastq_validator.validate_fastq_files_in_path([tmp_path], 2)
-    #
-    #     assert fastq_validator.errors
-
     def test_fastq_comparison_bad_unequal_line_counts(self, fastq_validator, tmp_path):
         good_file = "3252_ftL_RNA_T1_S31_L003_R1_001.fastq"
         bad_file = "3252_ftL_RNA_T1_S31_L003_R2_001.fastq"
@@ -293,3 +240,95 @@ NACTGACTGA
         fastq_validator.validate_fastq_files_in_path([tmp_path], 2)
 
         assert fastq_validator.errors
+
+    def test_fastq_groups_good(self, fastq_validator, tmp_path):
+        files = [
+            "20147_Healthy_PA_S1_L001_R1_001.fastq",
+            "20147_Healthy_PA_S1_L001_R2_001.fastq",
+            "20147_Healthy_PA_S1_L001_R3_001.fastq",
+            "20147_Healthy_PA_S1_L001_R1_002.fastq",
+            "20147_Healthy_PA_S1_L001_R2_002.fastq",
+        ]
+        for file in files:
+            with _open_output_file(tmp_path.joinpath(file), False) as output:
+                output.write(_GOOD_RECORDS)
+
+        fastq_validator.validate_fastq_files_in_path([tmp_path], 2)
+        assert fastq_validator._make_groups() == {
+            filename_pattern(prefix="20147_Healthy_PA_S1_L001", read_type="R", set_num="001"): [
+                PosixPath(tmp_path.joinpath("20147_Healthy_PA_S1_L001_R1_001.fastq")),
+                PosixPath(tmp_path.joinpath("20147_Healthy_PA_S1_L001_R2_001.fastq")),
+                PosixPath(tmp_path.joinpath("20147_Healthy_PA_S1_L001_R3_001.fastq")),
+            ],
+            filename_pattern(prefix="20147_Healthy_PA_S1_L001", read_type="R", set_num="002"): [
+                PosixPath(tmp_path.joinpath("20147_Healthy_PA_S1_L001_R1_002.fastq")),
+                PosixPath(tmp_path.joinpath("20147_Healthy_PA_S1_L001_R2_002.fastq")),
+            ],
+        }
+        assert not fastq_validator.errors
+
+    def test_fastq_groups_bad(self, fastq_validator, tmp_path):
+        good_files = [
+            "20147_Healthy_PA_S1_L001_R1_001.fastq",
+            "20147_Healthy_PA_S1_L001_R2_001.fastq",
+            "20147_Healthy_PA_S1_L001_R1_002.fastq",
+        ]
+        bad_files = [
+            "20147_Healthy_PA_S1_L001_R3_001.fastq",
+            "20147_Healthy_PA_S1_L001_R2_002.fastq",
+        ]
+        for file in good_files:
+            with _open_output_file(tmp_path.joinpath(file), False) as output:
+                output.write(_GOOD_RECORDS)
+        for file in bad_files:
+            with _open_output_file(tmp_path.joinpath(file), False) as output:
+                output.write("@bad")
+
+        fastq_validator.validate_fastq_files_in_path([tmp_path], 2)
+        assert "Counts do not match" in fastq_validator.errors[0]
+        assert "20147_Healthy_PA_S1_L001_R2_002.fastq" in fastq_validator.errors[0]
+        assert "Counts do not match" in fastq_validator.errors[1]
+        assert "20147_Healthy_PA_S1_L001_R3_001.fastq" in fastq_validator.errors[1]
+
+    def test_filename_valid_and_fastq_valid_but_not_grouped(self, fastq_validator, tmp_path):
+        # good_filenames[0:6] are valid but would not be grouped for comparison
+        good_filenames = [
+            "B001A001_1.fastq",  # no lane, read_type, or set
+            "B001A001_R1.fq",  # no lane or set
+            "B001A001_I1.fastq.gz",  # no lane or set
+            "H4L1-4_S64_R1_001.fastq.gz",  # no lane
+            "H4L1-4_S64_L001_001.fastq.gz",  # no read_type
+            "H4L1-4_S64_L001_R1.fastq.gz",  # no set
+            "L001_H4L1-4_S64_R1_001.fastq.gz",  # out of order
+            "H4L1-4_S64_L001_R1_001.fastq.gz",
+            "H4L1-4_S64_L001_R2_001.fastq.gz",
+            "H4L1-4_S64_L001_I1_001.fastq.gz",
+            "Undetermined_S0_L001_R1_001.W105_Small_bowel_ileum.trimmed.fastq.gz",  # annotated but otherwise fits pattern
+        ]
+        for file in good_filenames:
+            use_gzip = bool("gz" in file)
+            with _open_output_file(tmp_path.joinpath(file), use_gzip) as output:
+                output.write(_GOOD_RECORDS)
+
+        fastq_validator.validate_fastq_files_in_path([tmp_path], 2)
+        # All files in good_filenames should be in file_list
+        assert {
+            PosixPath(tmp_path.joinpath(file)) in fastq_validator.file_list
+            for file in good_filenames
+        } == {True}
+        # No errors should be found in any of those files
+        assert not fastq_validator.errors
+        # Only some files from good_filenames will match criteria for grouping
+        valid_filename_patterns = [
+            get_prefix_read_type_and_set(str(file))
+            for file in fastq_validator.file_list
+            if get_prefix_read_type_and_set(str(file)) is not None
+        ]
+        assert valid_filename_patterns == [
+            filename_pattern(prefix=f"{tmp_path}/H4L1-4_S64_L001", read_type="R", set_num="001"),
+            filename_pattern(prefix=f"{tmp_path}/H4L1-4_S64_L001", read_type="R", set_num="001"),
+            filename_pattern(prefix=f"{tmp_path}/H4L1-4_S64_L001", read_type="I", set_num="001"),
+            filename_pattern(
+                prefix=f"{tmp_path}/Undetermined_S0_L001", read_type="R", set_num="001"
+            ),
+        ]

--- a/tests/test_fastq_validator_logic.py
+++ b/tests/test_fastq_validator_logic.py
@@ -2,7 +2,6 @@ import gzip
 from pathlib import Path, PosixPath
 from typing import TextIO
 
-import fastq_utils
 import pytest
 
 from src.ingest_validation_tests.fastq_validator_logic import (

--- a/tests/test_fastq_validator_logic.py
+++ b/tests/test_fastq_validator_logic.py
@@ -272,6 +272,7 @@ NACTGACTGA
             "20147_Healthy_PA_S1_L001_R1_001.fastq",
             "20147_Healthy_PA_S1_L001_R2_001.fastq",
             "20147_Healthy_PA_S1_L001_R1_002.fastq",
+            "test_not_grouped_but_valid",
         ]
         bad_files = [
             "20147_Healthy_PA_S1_L001_R3_001.fastq",
@@ -291,7 +292,7 @@ NACTGACTGA
         assert "20147_Healthy_PA_S1_L001_R3_001.fastq" in fastq_validator.errors[1]
 
     def test_filename_valid_and_fastq_valid_but_not_grouped(self, fastq_validator, tmp_path):
-        # good_filenames[0:6] are valid but would not be grouped for comparison
+        # good_filenames[0:6] are valid in pipeline processing but would not be grouped for comparison
         good_filenames = [
             "B001A001_1.fastq",  # no lane, read_type, or set
             "B001A001_R1.fq",  # no lane or set
@@ -332,3 +333,15 @@ NACTGACTGA
                 prefix=f"{tmp_path}/Undetermined_S0_L001", read_type="R", set_num="001"
             ),
         ]
+        assert (
+            fastq_validator._ungrouped_files.sort()
+            == [
+                "B001A001_1.fastq",  # no lane, read_type, or set
+                "B001A001_R1.fq",  # no lane or set
+                "B001A001_I1.fastq.gz",  # no lane or set
+                "H4L1-4_S64_R1_001.fastq.gz",  # no lane
+                "H4L1-4_S64_L001_001.fastq.gz",  # no read_type
+                "H4L1-4_S64_L001_R1.fastq.gz",  # no set
+                "L001_H4L1-4_S64_R1_001.fastq.gz",  # out of order
+            ].sort()
+        )


### PR DESCRIPTION
Apologies for the extensive note. This is kinda noodly stuff so I wanted to pull together the results of my requirements gathering / process of understanding the problem into some form of context. If you feel like you get this already you can skip to "Assumptions that need review" for the real ask here.

## Context
FASTQ file validation previously compared all FASTQ files in a given directory against each other if the filenames matched a certain regex. That regex looked for the presence of a lane number and read type (see `Filenames` below for explanation). This seems to have worked fine because directories seem to have contained 2* files that needed to be compared against each other.

Recently, a case came up where files had trailing set numbers (001, 002, etc.)**. All files within a given set should be compared against each other, but not against other sets. Our plugin was not setup to accommodate this, hence this change.

\* In the case of read_type `R`, since the regex looked for only `R1` and `R2`, any `R3` files that may have been present would have been ignored / not compared to the other two. I *believe* SNARE-seq can have R3 files (the [dir schema](https://hubmapconsortium.github.io/ingest-validation-tools/snareseq2/current/) references this as being part of ATACseq sequencing).
\** These set numbers actually just denote that a file has been split into _n_ chunks. So you want to compare chunk 001 to chunk 001, etc.

### Filenames
The filenames we are considering should look something like this:

```arbitrary_prefix_L001_R1_001.fastq```

arbitrary_prefix = anything preceding the lane number
L001 = lane number, identified as `L` followed by digits followed by an underscore
R1 = read type (can be `R`, `I`, or potentially `read`--see below) followed by a digit followed by an underscore
001 = set number
.fastq = extension, can also be .fq / .fastq.gz but we leave this validation up to CMU's `fastq_utils` module

### Comparison example

Given the following files:
```
20147_Healthy_PA_S1_L001_R1_001.fastq.gz
20147_Healthy_PA_S1_L001_R1_002.fastq.gz
20147_Healthy_PA_S1_L001_R2_001.fastq.gz
20147_Healthy_PA_S1_L001_R2_002.fastq.gz
```
we want to compare line numbers between those with matching prefixes and set numbers.

So we want those in set 001 compared to each other:
```
20147_Healthy_PA_S1_L001_R1_001.fastq.gz
20147_Healthy_PA_S1_L001_R2_001.fastq.gz
```
And those in set 002 compared to each other:
```
20147_Healthy_PA_S1_L001_R1_002.fastq.gz
20147_Healthy_PA_S1_L001_R2_002.fastq.gz
```

## Assumptions that need review

Changes from previous functionality, based on assumptions that probably need co-signing:
- fastq_utils allows for `read` in addition to `R`/`I` as read types (i.e. read1, read2, read3). I mimicked this.
- Set number suffix treated as non-optional. This is a change from previous functionality which ignored everything after the read number. 
     - This means that a file named `arbitrary_prefix_L001_R1.fastq` would not be captured for comparison, even if there was another matching file (e.g. `arbitrary_prefix_L001_R2.fastq`) in the same directory. 

Other changes that do not conflict with previous functionality, based on other assumptions:
- Allows arbitrary text between set_num and fastq extension. 
     - Meaning that `arbitrary_prefix_L001_R1_001_blahblahblah.fastq` would get compared against any other files starting with the same `arbitrary_prefix_L001_R#_001` pattern.
- Allows files that match prefix/read/set pattern but do not have a pair to compare against. In the case where you have the following files:

1. 20147_Healthy_PA_S1_L001_R1_001.fastq.gz
2. 20147_Healthy_PA_S1_L001_R2_001.fastq.gz
3. 20147_Healthy_PA_S1_L001_R1_002.fastq.gz

...files 1 & 2 should have matching line counts, but file 3 has nothing to be compared to and therefore will be passed over. Not sure if this should be allowed to happen but currently it is logged and permitted.