### PR TITLE
Fixing issue with duplicates being compared across top-level data_paths

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,12 @@
 #!/usr/bin/env bash
+
+# Accepts additional args to pass to pytest
+# Accepts flags as individual args as well as
+# custom "--test=" arg which can be used to run a specific
+# test file/class/test just as you would pass it to pytest directly.
+# Example:
+# ./test.sh "--test=tests/test_fastq_validator_logic.py::TestFASTQValidatorLogic::test_fastq_groups_good" --pdb
+
 set -o errexit
 
 red="$(tput setaf 1)"
@@ -14,5 +22,5 @@ path_to_tools='../ingest-validation-tools'
 start placeholder
 ${path_to_tools}/src/validate_upload.py --help > /dev/null \
     || die 'validate_upload.py failed'
-python tests/pytest_runner.py ${path_to_tools}
+python tests/pytest_runner.py ${path_to_tools} "$@"
 end placeholder

--- a/tests/pytest_runner.py
+++ b/tests/pytest_runner.py
@@ -24,13 +24,24 @@ class add_path:
 
 
 def main():
-    if len(sys.argv) != 2:
+    """
+    Receives args from test.sh but can also accept pytest flags or
+    custom --test= arg directly, e.g.
+    python tests/pytest_runner.py '../ingest-validation-tools/' --test="tests/test_fastq_validator_logic.py::TestFASTQValidatorLogic::test_fastq_groups_good" --pdb
+    """
+    if len(sys.argv) < 2:
         sys.exit(f"usage: {sys.argv[0]} path-to-ingest-validation-tools")
     tools_path = Path(sys.argv[1]).resolve() / "src"
     plugins_path = Path(__file__).resolve().parent.parent / "src" / "ingest_validation_tests"
     with add_path(str(tools_path)):
         with add_path(str(plugins_path)):
-            sys.exit(pytest.main(["-vv"]))
+            args = ["-vv"]
+            for arg in sys.argv[2:]:
+                if arg.startswith("--test="):
+                    args.append(arg.replace("--test=", ""))
+                else:
+                    args.append(arg)
+            sys.exit(pytest.main(args))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Fixing issue with duplicates being compared across top-level data_path values for fastq validation
     - This was a bug I introduced with my previous fastq updates
- Wrote a test for this functionality
- Updated testing to allow passing test info/flags to pytest from test.sh