### PR TITLE
FASTQ fixes

### DIFF
--- a/src/ingest_validation_tests/fastq_validator_logic.py
+++ b/src/ingest_validation_tests/fastq_validator_logic.py
@@ -35,8 +35,8 @@ def get_prefix_read_type_and_set(filename: str) -> Optional[filename_pattern]:
     May also include: arbitrary text, set_num
 
     Regex documentation:
-        BEFORE_READ (?P<before_read>.*_L\\d{3}_.*(...))
-            - named capture group `before_read` must include pattern L###_
+        BEFORE_READ (?P<before_read>.*_L\\d+_.*(...))
+            - named capture group `before_read` must include pattern L<one or more digits>_
               before the READ subpattern defined below, can contain
               arbitrary other characters
         READ (?=(?P<entire_read>(?P<read>R|I)\\d(?=_|\\.)))
@@ -49,7 +49,7 @@ def get_prefix_read_type_and_set(filename: str) -> Optional[filename_pattern]:
               after `entire_read`
         NOTE
             - If named groups are needed for prefix/lane, replace before_read with:
-                (?P<before_read>(?P<prefix>.*(?=(?P<lane>L\\d{3})_)).*
+                (?P<before_read>(?P<prefix>.*(?=(?P<lane>L\\d+)_)).*
             - If we need set number, lane, etc., consider switching to a series
               of regex patterns
     """
@@ -57,7 +57,7 @@ def get_prefix_read_type_and_set(filename: str) -> Optional[filename_pattern]:
         return
 
     pattern = re.compile(
-        r"(?P<before_read>.*L\d{3}_.*(?=(?P<entire_read>(?P<read>R|I)\d(?=_|\.))))(?=(?P=entire_read)(?P<after_read>.+))"
+        r"(?P<before_read>.*L\d+_.*(?=(?P<entire_read>(?P<read>R|I)\d(?=_|\.))))(?=(?P=entire_read)(?P<after_read>.+))"
     )
     groups = pattern.match(filename)
     if groups:

--- a/src/ingest_validation_tests/fastq_validator_logic.py
+++ b/src/ingest_validation_tests/fastq_validator_logic.py
@@ -13,43 +13,69 @@ from typing import Callable, List, Optional, TextIO, Union
 import fastq_utils
 from typing_extensions import Self
 
-filename_pattern = namedtuple("filename_pattern", ["prefix", "read_type", "set_num"])
+filename_pattern = namedtuple("filename_pattern", ["before_read", "read", "after_read"])
 
 
 def is_valid_filename(filename: str) -> bool:
     return bool(fastq_utils.FASTQ_PATTERN.fullmatch(filename))
 
 
+def get_filename(pattern: filename_pattern) -> str:
+    return f"{pattern.before_read}{pattern.read}#{pattern.after_read}"
+
+
 def get_prefix_read_type_and_set(filename: str) -> Optional[filename_pattern]:
     """
-    Looking for fastq filenames matching pattern:
-    <prefix>_<lane:L#+>_<read_type:I,R,read>#_<set_num:#+>
-    e.g. arbitrary_string_L001_R1_001.fastq
+    Looking for fastq filenames with a particular format to compare record counts.
+
+    Expected pattern:
+        - <arbitrary_text>_<lane:L#+>_<read_type:I,R,read>#_<set_num:#+>.<fastq,fastq.gz,fq>
+        - e.g. arbitrary_string_L001_R1_001.fastq
+    Minimum required elements: lane (must occur before read), read
+    May also include: arbitrary text, set_num
 
     Regex documentation:
-        PREFIX
-            - (?P<prefix> | named capture group "prefix"
-            - .*(?:L\\d+) | match anything before and including pattern L# (where # represents 1 or more digits)
-            - only capture prefix if read_type and set_num found
-        READ_TYPE
-            - (?=_ | assert that the character "_" is present at the beginning of this next group
-            - (?:(?P<read_type>R|read(?=[123])|I(?=[12]))) | only capture above match if followed by the
-               sequence _[R1,R2,R3,read1,read2,read3,I1,I2]; capture R/I/read as read_type, discarding digit
-        SET_NUM
-            - (?:\\d_ | ensure presence of "#_" before group, ignore characters
-            - (?P<set_num>\\d+) | capture group set_num of 1 or more digits
-               Note: if set_num needs to be optional, could change this portion to (?:\\d_?(?P<set_num>\\d+)|)
+        BEFORE_READ (?P<before_read>.*_L\\d{3}_.*(...))
+            - named capture group `before_read` must include pattern L###_
+              before the READ subpattern defined below, can contain
+              arbitrary other characters
+        READ (?=(?P<entire_read>(?P<read>R|I)\\d(?=_|\\.)))
+            - subpattern of BEFORE_READ that ensures the presence
+              of the `entire_read` pattern (_<R,I>#<_,.>) and captures the
+              `read` type (R or I)
+        AFTER_READ (?=(?P=entire_read)(?P<after_read>.+))
+            - ensures the presence of the `entire_read` pattern before
+              named capture group `after_read`, which captures everything
+              after `entire_read`
+        NOTE
+            - If named groups are needed for prefix/lane, replace before_read with:
+                (?P<before_read>(?P<prefix>.*(?=(?P<lane>L\\d{3})_)).*
+            - If we need set number, lane, etc., consider switching to a series
+              of regex patterns
     """
     if not bool(fastq_utils.FASTQ_PATTERN.fullmatch(filename)):
         return
+
     pattern = re.compile(
-        r"(?P<prefix>.*(?:L\d+)(?=_(?P<read_type>R|read(?=[123])|I(?=[12]))(?:\d_(?P<set_num>\d+))))"
+        r"(?P<before_read>.*L\d{3}_.*(?=(?P<entire_read>(?P<read>R|I)\d(?=_|\.))))(?=(?P=entire_read)(?P<after_read>.+))"
     )
     groups = pattern.match(filename)
-    if groups and all(x in groups.groupdict().keys() for x in ["prefix", "read_type", "set_num"]):
+    if groups:
         return filename_pattern(
-            groups.group("prefix"), groups.group("read_type"), groups.group("set_num")
+            groups.group("before_read"), groups.group("read"), groups.group("after_read")
         )
+
+
+def printable_filenames(files: Union[list, ListProxy, Path, str], newlines: bool = True):
+    if type(files) is list or type(files) is ListProxy:
+        file_list = [str(file) for file in files]
+        if newlines:
+            return "\n".join(file_list)
+        return file_list
+    elif type(files) is Path:
+        return str(files)
+    elif type(files) is str:
+        return files
 
 
 def _open_fastq_file(file: Path) -> TextIO:
@@ -244,9 +270,9 @@ class FASTQValidatorLogic:
                 # Combine all paths' file lists to parallelize processing more efficiently.
                 full_file_list = list(chain.from_iterable(self.files_by_path.values()))
                 logging.info(
-                    f"Passing file list for paths {self._printable_filenames(paths, newlines=False)} to engine. File list:"
+                    f"Passing file list for paths {printable_filenames(paths, newlines=False)} to engine. File list:"
                 )
-                logging.info(self._printable_filenames(full_file_list, newlines=True))
+                logging.info(printable_filenames(full_file_list, newlines=True))
                 engine = Engine(self)
                 data_output = pool.imap_unordered(engine, full_file_list)
                 [data_found_one.extend(output) for output in data_output if output]
@@ -311,25 +337,12 @@ class FASTQValidatorLogic:
                     comparison[str(path)] = self._file_record_counts.get(str(path))
                 if not (len(set(comparison.values())) == 1):
                     self.errors.append(
-                        f"Counts do not match among files matching pattern {pattern.prefix}_{pattern.read_type}#_{pattern.set_num}: {comparison}"
+                        f"Counts do not match among files matching pattern {get_filename(pattern)}: {comparison}"
                     )
                 else:
                     _log(
-                        f"PASSED: Record count comparison for files matching pattern {pattern.prefix}_{pattern.read_type}#_{pattern.set_num}: {comparison}"
+                        f"PASSED: Record count comparison for files matching pattern {get_filename(pattern)}: {comparison}"
                     )
-
-    def _printable_filenames(
-        self, files: Union[list, ListProxy, Path, str], newlines: bool = True
-    ):
-        if type(files) is list or type(files) is ListProxy:
-            file_list = [str(file) for file in files]
-            if newlines:
-                return "\n".join(file_list)
-            return file_list
-        elif type(files) is Path:
-            return str(files)
-        elif type(files) is str:
-            return files
 
 
 def main():

--- a/tests/test_fastq_validator_logic.py
+++ b/tests/test_fastq_validator_logic.py
@@ -286,10 +286,11 @@ NACTGACTGA
                 output.write("@bad")
 
         fastq_validator.validate_fastq_files_in_path([tmp_path], 2)
-        assert "Counts do not match" in fastq_validator.errors[0]
-        assert "20147_Healthy_PA_S1_L001_R2_002.fastq" in fastq_validator.errors[0]
-        assert "Counts do not match" in fastq_validator.errors[1]
-        assert "20147_Healthy_PA_S1_L001_R3_001.fastq" in fastq_validator.errors[1]
+        sorted_errors = sorted(fastq_validator.errors)
+        assert "Counts do not match" in sorted_errors[0]
+        assert "20147_Healthy_PA_S1_L001_R3_001.fastq" in sorted_errors[0]
+        assert "Counts do not match" in sorted_errors[1]
+        assert "20147_Healthy_PA_S1_L001_R2_002.fastq" in sorted_errors[1]
 
     def test_filename_valid_and_fastq_valid_but_not_grouped(self, fastq_validator, tmp_path):
         # good_filenames[0:6] are valid in pipeline processing but would not be grouped for comparison

--- a/tests/test_fastq_validator_logic.py
+++ b/tests/test_fastq_validator_logic.py
@@ -255,12 +255,16 @@ NACTGACTGA
 
         fastq_validator.validate_fastq_files_in_path([tmp_path], 2)
         assert fastq_validator._make_groups(files) == {
-            filename_pattern(prefix="20147_Healthy_PA_S1_L001", read_type="R", set_num="001"): [
+            filename_pattern(
+                before_read="20147_Healthy_PA_S1_L001_", read="R", after_read="_001.fastq"
+            ): [
                 PosixPath(tmp_path.joinpath("20147_Healthy_PA_S1_L001_R1_001.fastq")),
                 PosixPath(tmp_path.joinpath("20147_Healthy_PA_S1_L001_R2_001.fastq")),
                 PosixPath(tmp_path.joinpath("20147_Healthy_PA_S1_L001_R3_001.fastq")),
             ],
-            filename_pattern(prefix="20147_Healthy_PA_S1_L001", read_type="R", set_num="002"): [
+            filename_pattern(
+                before_read="20147_Healthy_PA_S1_L001_", read="R", after_read="_002.fastq"
+            ): [
                 PosixPath(tmp_path.joinpath("20147_Healthy_PA_S1_L001_R1_002.fastq")),
                 PosixPath(tmp_path.joinpath("20147_Healthy_PA_S1_L001_R2_002.fastq")),
             ],
@@ -293,19 +297,19 @@ NACTGACTGA
         assert "20147_Healthy_PA_S1_L001_R2_002.fastq" in sorted_errors[1]
 
     def test_filename_valid_and_fastq_valid_but_not_grouped(self, fastq_validator, tmp_path):
-        # good_filenames[0:6] are valid in pipeline processing but would not be grouped for comparison
+        # good_filenames[0:5] are valid in pipeline processing but would not be grouped for comparison
         good_filenames = [
             "B001A001_1.fastq",  # no lane, read_type, or set
             "B001A001_R1.fq",  # no lane or set
             "B001A001_I1.fastq.gz",  # no lane or set
             "H4L1-4_S64_R1_001.fastq.gz",  # no lane
             "H4L1-4_S64_L001_001.fastq.gz",  # no read_type
-            "H4L1-4_S64_L001_R1.fastq.gz",  # no set
-            "L001_H4L1-4_S64_R1_001.fastq.gz",  # out of order
-            "H4L1-4_S64_L001_R1_001.fastq.gz",
-            "H4L1-4_S64_L001_R2_001.fastq.gz",
-            "H4L1-4_S64_L001_I1_001.fastq.gz",
-            "Undetermined_S0_L001_R1_001.W105_Small_bowel_ileum.trimmed.fastq.gz",  # annotated but otherwise fits pattern
+            "H4L1-4_S64_L001_R1.fastq.gz",  # will try to group; no set
+            "L001_H4L1-4_S64_R1_001.fastq.gz",  # will try to group; out of order but has required elements
+            "H4L1-4_S64_L001_R1_001.fastq.gz",  # will try to group; will be compared
+            "H4L1-4_S64_L001_R2_001.fastq.gz",  # will try to group; will be compared
+            "H4L1-4_S64_L001_I1_001.fastq.gz",  # will try to group; read type `I`
+            "Undetermined_S0_L001_R1_001.W105_Small_bowel_ileum.trimmed.fastq.gz",  # will try to group; annotated but otherwise fits pattern
         ]
         for file in good_filenames:
             use_gzip = bool("gz" in file)
@@ -327,23 +331,39 @@ NACTGACTGA
             if get_prefix_read_type_and_set(str(file)) is not None
         ]
         assert sorted(
-            valid_filename_patterns, key=attrgetter("prefix", "read_type", "set_num")
+            valid_filename_patterns, key=attrgetter("before_read", "read", "after_read")
         ) == sorted(
             [
                 filename_pattern(
-                    prefix=f"{tmp_path}/H4L1-4_S64_L001", read_type="R", set_num="001"
+                    before_read=f"{tmp_path}/H4L1-4_S64_L001_", read="R", after_read=".fastq.gz"
                 ),
                 filename_pattern(
-                    prefix=f"{tmp_path}/H4L1-4_S64_L001", read_type="R", set_num="001"
+                    before_read=f"{tmp_path}/L001_H4L1-4_S64_",
+                    read="R",
+                    after_read="_001.fastq.gz",
                 ),
                 filename_pattern(
-                    prefix=f"{tmp_path}/H4L1-4_S64_L001", read_type="I", set_num="001"
+                    before_read=f"{tmp_path}/H4L1-4_S64_L001_",
+                    read="R",
+                    after_read="_001.fastq.gz",
                 ),
                 filename_pattern(
-                    prefix=f"{tmp_path}/Undetermined_S0_L001", read_type="R", set_num="001"
+                    before_read=f"{tmp_path}/H4L1-4_S64_L001_",
+                    read="R",
+                    after_read="_001.fastq.gz",
+                ),
+                filename_pattern(
+                    before_read=f"{tmp_path}/H4L1-4_S64_L001_",
+                    read="I",
+                    after_read="_001.fastq.gz",
+                ),
+                filename_pattern(
+                    before_read=f"{tmp_path}/Undetermined_S0_L001_",
+                    read="R",
+                    after_read="_001.W105_Small_bowel_ileum.trimmed.fastq.gz",
                 ),
             ],
-            key=attrgetter("prefix", "read_type", "set_num"),
+            key=attrgetter("before_read", "read", "after_read"),
         )
         assert (
             fastq_validator._ungrouped_files.sort()


### PR DESCRIPTION
The previous regex that grouped FASTQ files for record count comparison was very strictly designed to the filename spec that emerged from previous discussions. However, in practice, there has already been an exception to that spec leading to files that should have been compared to each other being skipped. Since the upstream dir schema validation and downstream pipeline `fastq_utils` are both permissive of these variations, this PR makes the regex much less opinionated.

What the regex does now to match up files:
- Looks for the presence of a lane and read value in the filename.
- If present, separates the filename into before_read, read, and after_read portions--this omits the only portion of the name that should be different, which is the read number.
- Compares files that share the same before_read, read, and after_read portions.

Example:
Given filenames `text_L001_R1_001.fastq` and `text_L001_R2_001.fastq`, they will both share the same values for before_read (text_L001_), read (R), and after_read (_001.fastq) and will therefore be compared.

This PR also fixes a fastq test that @jswelling found was broken in different environments due to differences in sorting.

Two uncertainties:
- I chose to keep the requirement that a lane value be present; this could be removed as well which would bring the regex more in line with the directory schema regex pattern.
- I still chose to log rather than throw an exception when files are skipped.