### PR TITLE
OME TIFF field validator: optional Pixels_PhysicalSizeZ fields

### DIFF
--- a/src/ingest_validation_tests/ome_tiff_field_validator.py
+++ b/src/ingest_validation_tests/ome_tiff_field_validator.py
@@ -60,10 +60,7 @@ def check_one_prop(key: str, all_image_props: list, this_test: dict) -> None:
         for val in [thisval for thiskey, thisval in all_image_props if thiskey == key]:
             if allowed_vals := this_test.get("allowed_values"):
                 assert val in allowed_vals, f"{key} == {val} is not one of {allowed_vals}"
-            else:
-                assert isinstance(
-                    val, test_type_map[test_type]
-                ), f"{key} = {val} is not a {test_type}"
+            assert isinstance(val, test_type_map[test_type]), f"{key} = {val} is not a {test_type}"
     else:
         raise NotImplementedError(f"Unimplemented dtype {test_type} for ome-tiff field")
 

--- a/src/ingest_validation_tests/ome_tiff_field_validator.py
+++ b/src/ingest_validation_tests/ome_tiff_field_validator.py
@@ -65,7 +65,8 @@ def check_one_prop(key: str, all_prop_list: list, this_test: dict) -> None:
         for val in [thisval for thiskey, thisval in all_prop_list if thiskey == key]:
             assert isinstance(val, int), f"{key} = {val} is not an int"
     elif test_type == "float":
-        assert key in all_prop_keys, f"{key} is required but missing"
+        if not this_test.get("optional"):
+            assert key in all_prop_keys, f"{key} is required but missing"
         for val in [thisval for thiskey, thisval in all_prop_list if thiskey == key]:
             assert isinstance(val, float), f"{key} = {val} is not a float"
     else:

--- a/src/ingest_validation_tests/ome_tiff_fields.json
+++ b/src/ingest_validation_tests/ome_tiff_fields.json
@@ -84,14 +84,14 @@
       "Pixels_PhysicalSizeZ": {
         "dtype": "float",
         "msg": "dtype should be float",
-        "required_field": true
+        "required_field": false
       },
       "Pixels_PhysicalSizeZUnit": {
         "dtype": "categorical",
         "allowed_values": [
           "µm"
         ],
-        "required_field": true
+        "required_field": false
       }
     }
   }

--- a/src/ingest_validation_tests/ome_tiff_fields.json
+++ b/src/ingest_validation_tests/ome_tiff_fields.json
@@ -45,7 +45,8 @@
       },
       "Pixels_PhysicalSizeZ": {
 	"dtype": "float",
-	"msg": "dtype should be float"
+	"msg": "dtype should be float",
+    "optional": true
       },
       "Pixels_PhysicalSizeZUnit": {
 	"dtype": "categorical",

--- a/src/ingest_validation_tests/ome_tiff_fields.json
+++ b/src/ingest_validation_tests/ome_tiff_fields.json
@@ -1,56 +1,97 @@
 [
   {
+    "name": "default_shared_requirements",
     "re": ".*",
     "fields": {
       "Pixels_DimensionOrder": {
-	"dtype": "categorical",
-	"allowed_values": ["XYZCT", "XYZTC", "XYCTZ", "XYCZT", "XYTCZ", "XYTZC"]
+        "dtype": "categorical",
+        "allowed_values": [
+          "XYZCT",
+          "XYZTC",
+          "XYCTZ",
+          "XYCZT",
+          "XYTCZ",
+          "XYTZC"
+        ],
+        "required_field": true
       },
       "Pixels_Type": {
-	"dtype": "categorical",
-	"allowed_values": ["bit", "complex", "double", "double-complex", "float",
-			   "int8", "int12", "int14", "int16", "int32", "uint8",
-			   "uint12", "uint14", "uint16", "uint32", "Other"]
+        "dtype": "categorical",
+        "allowed_values": [
+          "bit",
+          "complex",
+          "double",
+          "double-complex",
+          "float",
+          "int8",
+          "int12",
+          "int14",
+          "int16",
+          "int32",
+          "uint8",
+          "uint12",
+          "uint14",
+          "uint16",
+          "uint32",
+          "Other"
+        ],
+        "required_field": true
       },
       "Pixels_SizeX": {
-	"dtype": "integer"
+        "dtype": "integer",
+        "required_field": true
       },
       "Pixels_SizeY": {
-	"dtype": "integer"
+        "dtype": "integer",
+        "required_field": true
       },
       "Pixels_SizeZ": {
-	"dtype": "integer"
+        "dtype": "integer",
+        "required_field": true
       },
       "Pixels_SizeC": {
-	"dtype": "integer"
+        "dtype": "integer",
+        "required_field": true
       },
       "Pixels_SizeT": {
-	"dtype": "integer"
+        "dtype": "integer",
+        "required_field": true
       },
       "Pixels_PhysicalSizeX": {
-	"dtype": "float",
-	"msg": "dtype should be float"
+        "dtype": "float",
+        "msg": "dtype should be float",
+        "required_field": true
       },
       "Pixels_PhysicalSizeXUnit": {
-	"dtype": "categorical",
-	"allowed_values": ["µm"]
+        "dtype": "categorical",
+        "allowed_values": [
+          "µm"
+        ],
+        "required_field": true
       },
       "Pixels_PhysicalSizeY": {
-	"dtype": "float",
-	"msg": "dtype should be float"
+        "dtype": "float",
+        "msg": "dtype should be float",
+        "required_field": true
       },
       "Pixels_PhysicalSizeYUnit": {
-	"dtype": "categorical",
-	"allowed_values": ["µm"]
+        "dtype": "categorical",
+        "allowed_values": [
+          "µm"
+        ],
+        "required_field": true
       },
       "Pixels_PhysicalSizeZ": {
-	"dtype": "float",
-	"msg": "dtype should be float",
-    "optional": true
+        "dtype": "float",
+        "msg": "dtype should be float",
+        "required_field": true
       },
       "Pixels_PhysicalSizeZUnit": {
-	"dtype": "categorical",
-	"allowed_values": ["µm"]
+        "dtype": "categorical",
+        "allowed_values": [
+          "µm"
+        ],
+        "required_field": true
       }
     }
   }

--- a/src/ingest_validation_tests/ome_tiff_fields_schema.json
+++ b/src/ingest_validation_tests/ome_tiff_fields_schema.json
@@ -38,7 +38,8 @@
 									}
 								},
 								"required": [
-									"dtype"
+									"dtype",
+									"required_field"
 								]
 							},
 							{
@@ -59,7 +60,8 @@
 								},
 								"required": [
 									"dtype",
-									"allowed_values"
+									"allowed_values",
+									"required_field"
 								]
 							}
 						]

--- a/src/ingest_validation_tests/ome_tiff_fields_schema.json
+++ b/src/ingest_validation_tests/ome_tiff_fields_schema.json
@@ -1,48 +1,77 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "http://schemata.hubmapconsortium.org/ome_tiff_fields_schema_schema.json",
-  "title": "ome-tiff fields schema",
-  "description": "schema for the definitions file of required ome-tiff fields",
-  "allOf":[{"$ref": "#/definitions/file_info"}],
-  "definitions": {
-    "file_info_record": {
-      "type": "object",
-      "properties": {
-	"re": {
-	  "type": "string",
-	  "description": "regular expression for assay types"
-	},
-	"fields": {
-	  "type": "object",
-	  "additionalProperties": {
-	    "oneOf": [
-	      {
-		"type": "object",
-		"properties": {
-		  "dtype": {"enum": ["integer", "float"]},
-          "optional": {"type": "boolean"}
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "http://schemata.hubmapconsortium.org/ome_tiff_fields_schema_schema.json",
+	"title": "ome-tiff fields schema",
+	"description": "schema for the definitions file of required ome-tiff fields",
+	"allOf": [
+		{
+			"$ref": "#/definitions/file_info"
+		}
+	],
+	"definitions": {
+		"file_info_record": {
+			"type": "object",
+			"properties": {
+				"name": {
+					"type": "string",
+					"description": "the name of this requirements set"
+				},
+				"re": {
+					"type": "string",
+					"description": "regular expression for assay types"
+				},
+				"fields": {
+					"type": "object",
+					"additionalProperties": {
+						"oneOf": [
+							{
+								"type": "object",
+								"properties": {
+									"dtype": {
+										"enum": [
+											"integer",
+											"float"
+										]
+									},
+									"required_field": {
+										"type": "boolean"
+									}
+								},
+								"required": [
+									"dtype"
+								]
+							},
+							{
+								"type": "object",
+								"properties": {
+									"dtype": {
+										"enum": [
+											"categorical"
+										]
+									},
+									"allowed_values": {
+										"type": "array",
+										"items": {
+											"type": "string"
+										},
+										"required_field": "boolean"
+									}
+								},
+								"required": [
+									"dtype",
+									"allowed_values"
+								]
+							}
+						]
+					}
+				}
+			}
 		},
-		"required": ["dtype"]
-	      },
-	      {
-		"type": "object",
-		"properties": {
-		  "dtype": {"enum": ["categorical"]},
-		  "allowed_values": {
-		    "type": "array",
-		    "items": {"type": "string"}
-		  }
-		},
-		"required": ["dtype", "allowed_values"]
-	      }
-	    ]
-	  }
+		"file_info": {
+			"type": "array",
+			"items": {
+				"$ref": "#/definitions/file_info_record"
+			}
+		}
 	}
-      }
-    },
-    "file_info": {
-      "type":  "array",
-      "items": {"$ref": "#/definitions/file_info_record"}
-    }
-  }
 }

--- a/src/ingest_validation_tests/ome_tiff_fields_schema.json
+++ b/src/ingest_validation_tests/ome_tiff_fields_schema.json
@@ -19,7 +19,8 @@
 	      {
 		"type": "object",
 		"properties": {
-		  "dtype": {"enum": ["integer", "float"]}
+		  "dtype": {"enum": ["integer", "float"]},
+          "optional": {"type": "boolean"}
 		},
 		"required": ["dtype"]
 	      },

--- a/tests/test_ome_tiff_field_validator.py
+++ b/tests/test_ome_tiff_field_validator.py
@@ -45,7 +45,7 @@ def test_ome_tiff_field_validator(test_data_fname, msg_re_list, assay_type, tmp_
         msg_re_list_dup = list(msg_re_list)  # to avoid editing during iteration
         match = False
         for re_str in msg_re_list_dup:
-            if (err_str is None and re_str is None) or re.match(
+            if (err_str is None and re_str is None) or re.fullmatch(
                 re_str, err_str, flags=re.MULTILINE
             ):
                 msg_re_list.remove(re_str)

--- a/tests/test_ome_tiff_field_validator.py
+++ b/tests/test_ome_tiff_field_validator.py
@@ -2,55 +2,117 @@ import re
 import zipfile
 from pathlib import Path
 
+import jsonschema
 import pytest
 
 
-@pytest.mark.parametrize(
-    ("test_data_fname", "msg_re_list", "assay_type"),
-    (
-        (
-            "test_data/codex_tree_ometiff_bad.zip",
-            [
-                ".*tubhiswt_C0_bad.ome.tif is not a valid OME.TIFF file.*",
-                ".*sample1.ome.tif is not a valid OME.TIFF file.*",
-                ".*sample2.ome.tif is not a valid OME.TIFF file.*",
-            ],
-            "CODEX",
-        ),
-        ("test_data/codex_tree_ometiff_good.zip", [], "CODEX"),
-        ("test_data/fake_snrnaseq_tree_good.zip", [], "snRNAseq"),
-        (
-            "test_data/complex_small_ome_tiff.zip",
-            [
-                ".*complex_small_ome_tiff/917_cropped_0_Z0_C3_T0.ome.tiff is not"
-                " a valid OME.TIFF file: Pixels_PhysicalSizeX is required but missing;"
-                " Pixels_PhysicalSizeY is required but missing"
-            ],
-            "PAS",
-        ),
-    ),
-)
-def test_ome_tiff_field_validator(test_data_fname, msg_re_list, assay_type, tmp_path):
-    from ome_tiff_field_validator import OmeTiffFieldValidator
+class TestOmeTiffFieldValidator:
 
-    test_data_path = Path(test_data_fname)
-    zfile = zipfile.ZipFile(test_data_path)
-    zfile.extractall(tmp_path)
-    validator = OmeTiffFieldValidator(tmp_path / test_data_path.stem, assay_type)
-    errors = validator.collect_errors(coreuse=4)[:]
-    errors = list(err for err in errors if err is not None)
-    assert len(msg_re_list) == len(errors)
-    unmatched_errors = []
-    for err_str in errors:
-        msg_re_list_dup = list(msg_re_list)  # to avoid editing during iteration
-        match = False
-        for re_str in msg_re_list_dup:
-            if (err_str is None and re_str is None) or re.fullmatch(
-                re_str, err_str, flags=re.MULTILINE
-            ):
-                msg_re_list.remove(re_str)
-                match = True
-                break
-        if not match:
-            unmatched_errors.append(err_str)
-    assert not unmatched_errors, f"Unmatched errors: {unmatched_errors}"
+    def validator(self, test_data_fname, assay_type, tmp_path):
+        from ome_tiff_field_validator import OmeTiffFieldValidator
+
+        test_data_path = Path(test_data_fname)
+        zfile = zipfile.ZipFile(test_data_path)
+        zfile.extractall(tmp_path)
+        return OmeTiffFieldValidator(tmp_path / test_data_path.stem, assay_type)
+
+    def check_errors(self, msg_re_list, errors):
+        assert len(msg_re_list) == len(errors)
+        unmatched_errors = []
+        for err_str in errors:
+            msg_re_list_dup = list(msg_re_list)  # to avoid editing during iteration
+            match = False
+            for re_str in msg_re_list_dup:
+                if (err_str is None and re_str is None) or re.fullmatch(
+                    re_str, err_str, flags=re.MULTILINE
+                ):
+                    msg_re_list.remove(re_str)
+                    match = True
+                    break
+            if not match:
+                unmatched_errors.append(err_str)
+        assert not unmatched_errors, f"Unmatched errors: {unmatched_errors}"
+
+    @pytest.mark.parametrize(
+        ("test_data_fname", "msg_re_list", "assay_type"),
+        (
+            (
+                "test_data/codex_tree_ometiff_bad.zip",
+                [
+                    ".*tubhiswt_C0_bad.ome.tif is not a valid OME.TIFF file.*",
+                    ".*sample1.ome.tif is not a valid OME.TIFF file.*",
+                    ".*sample2.ome.tif is not a valid OME.TIFF file.*",
+                ],
+                "CODEX",
+            ),
+            ("test_data/codex_tree_ometiff_good.zip", [], "CODEX"),
+            ("test_data/fake_snrnaseq_tree_good.zip", [], "snRNAseq"),
+            (
+                "test_data/complex_small_ome_tiff.zip",
+                [
+                    ".*complex_small_ome_tiff/917_cropped_0_Z0_C3_T0.ome.tiff is not"
+                    " a valid OME.TIFF file: Pixels_PhysicalSizeX is required but missing;"
+                    " Pixels_PhysicalSizeY is required but missing"
+                ],
+                "PAS",
+            ),
+        ),
+    )
+    def test_ome_tiff_field_validator(self, test_data_fname, msg_re_list, assay_type, tmp_path):
+        validator = self.validator(test_data_fname, assay_type, tmp_path)
+        errors = validator.collect_errors(coreuse=4)[:]
+        errors = list(err for err in errors if err is not None)
+        self.check_errors(msg_re_list, errors)
+
+    test_config_entry = {
+        "name": "test requirements",
+        "re": "test_dataset_type",
+        "fields": {
+            "Pixels_PhysicalSizeZ": {
+                "dtype": "float",
+                "msg": "dtype should be float",
+                "required_field": True,
+            },
+            "Pixels_PhysicalSizeZUnit": {
+                "dtype": "categorical",
+                "allowed_values": ["µm"],
+                "required_field": True,
+            },
+        },
+    }
+
+    @pytest.mark.parametrize(
+        ("test_data_fname", "msg_re_list", "assay_type"),
+        (
+            ("test_data/fake_snrnaseq_tree_good.zip", [], "test_dataset_type"),
+            (
+                "test_data/complex_small_ome_tiff.zip",
+                [
+                    ".*complex_small_ome_tiff/917_cropped_0_Z0_C3_T0.ome.tiff is not"
+                    " a valid OME.TIFF file: Pixels_PhysicalSizeX is required but missing;"
+                    " Pixels_PhysicalSizeY is required but missing;"
+                    " Pixels_PhysicalSizeZ is required but missing.*"
+                ],
+                "test_dataset_type",
+            ),
+            (
+                "test_data/complex_small_ome_tiff.zip",
+                [
+                    ".*complex_small_ome_tiff/917_cropped_0_Z0_C3_T0.ome.tiff is not"
+                    " a valid OME.TIFF file: Pixels_PhysicalSizeX is required but missing;"
+                    " Pixels_PhysicalSizeY is required but missing*"
+                ],
+                "PAS",
+            ),
+        ),
+    )
+    def test_multiple_test_cfgs(self, test_data_fname, msg_re_list, assay_type, tmp_path):
+        """
+        Make optional fields in default schema required for `test_dataset_type`.
+        Make sure PAS fixture from previous test still passes.
+        """
+        validator = self.validator(test_data_fname, assay_type, tmp_path)
+        validator.cfg_list.append(self.test_config_entry)
+        jsonschema.validate(validator.cfg_list, validator.schema)
+        errors = validator.collect_errors(coreuse=4)[:]
+        self.check_errors(msg_re_list, errors)

--- a/tests/test_ome_tiff_field_validator.py
+++ b/tests/test_ome_tiff_field_validator.py
@@ -24,8 +24,7 @@ import pytest
             [
                 ".*complex_small_ome_tiff/917_cropped_0_Z0_C3_T0.ome.tiff is not"
                 " a valid OME.TIFF file: Pixels_PhysicalSizeX is required but missing;"
-                " Pixels_PhysicalSizeY is required but missing;"
-                " Pixels_PhysicalSizeZ is required but missing"
+                " Pixels_PhysicalSizeY is required but missing"
             ],
             "PAS",
         ),


### PR DESCRIPTION
Major changes annotated by comments in PR:
- Updated `ome_tiff_fields.json` and `ome_tiff_fields_schema.json` to add `required_field: boolean`
- Checking for the presence of `required_field == True` in validation to avoid throwing error for optional fields, but still validating value if found
- Checked that you can override the default by adding additional entries to `ome_tiff_fields.json` (base functionality already set up by @jswelling); see new test in `tests/test_ome_tiff_field_validator.py` for example

Other changes:
- Renamed a few variables for readability, refactored a few functions to be more abstract, changed `OmeTiffFieldValidator.__init__` to allow for on-the-fly config changes (mostly for testing)
- JSON formatter went wild but I think it's more readable now so hopefully not a problem