### PR TITLE
Fixing empty file check

### DIFF
--- a/src/ingest_validation_tests/fastq_validator_logic.py
+++ b/src/ingest_validation_tests/fastq_validator_logic.py
@@ -206,8 +206,9 @@ class FASTQValidatorLogic:
                 self._format_error(error)
                 for error in self.validate_fastq_record(line.rstrip(), line_count)
             )
+            line_count += 1
 
-        return line_count + 1
+        return line_count
 
     def validate_fastq_file(self, fastq_file: Path) -> None:
         _log(f"Validating {fastq_file.name}...")

--- a/tests/test_fastq_validator_logic.py
+++ b/tests/test_fastq_validator_logic.py
@@ -86,6 +86,16 @@ class TestFASTQValidatorLogic:
         # overall file failed and that error messages were returned.
         assert fastq_validator.errors
 
+    def test_fastq_validator_empty_file(self, fastq_validator, tmp_path):
+        test_file = tmp_path.joinpath("test.fastq")
+        with _open_output_file(test_file, False) as output:
+            output.write("")
+
+        fastq_validator.validate_fastq_files_in_path([tmp_path], 2)
+
+        assert len(fastq_validator.errors) == 1
+        assert "empty" in fastq_validator.errors[0]
+
     def test_fastq_validator_io_error(self, fastq_validator, tmp_path):
         fake_path = tmp_path.joinpath("does-not-exist.fastq")
 
@@ -106,6 +116,7 @@ class TestFASTQValidatorLogic:
     def test_fastq_validator_line_1_empty(self, fastq_validator):
         result = fastq_validator.validate_fastq_record("", 0)
 
+        assert len(result) == 1
         assert "does not begin with '@'" in result[0]
 
     def test_fastq_validator_line_2_good(self, fastq_validator):


### PR DESCRIPTION
Thought I fixed this previously, but it was just wrong in a different way :melting_face: FASTQ validation has been confused about files that are empty vs. files with one line for a bit. Empty files should have been caught downstream when the validator checks them line by line (so it's been technically working) but the code that purports to catch empty files was not actually doing that.