### PR TITLE
Adding pool.join() to reap dead threads so the process can close and continue execution.

### DIFF
--- a/src/ingest_validation_tests/ome_tiff_field_validator.py
+++ b/src/ingest_validation_tests/ome_tiff_field_validator.py
@@ -72,6 +72,7 @@ class OmeTiffFieldValidator(Validator):
             if rslt is not None
         ]
         pool.close()
+        pool.join()
         return self._return_result(
             list(itertools.chain.from_iterable(rslt_list)) if rslt_list else None,
             filenames_to_test,

--- a/src/ingest_validation_tests/ome_tiff_validator.py
+++ b/src/ingest_validation_tests/ome_tiff_validator.py
@@ -29,4 +29,5 @@ class OmeTiffValidator(Validator):
             if rslt is not None
         )
         pool.close()
+        pool.join()
         return self._return_result(rslt_list, filenames_to_test)


### PR DESCRIPTION
Closes issue: https://github.com/hubmapconsortium/ingest-validation-tests/issues/95