### PR TITLE
URL check bugfix

### DIFF
--- a/src/ingest_validation_tests/publication_metadata_validator.py
+++ b/src/ingest_validation_tests/publication_metadata_validator.py
@@ -73,7 +73,8 @@ class PublicationMetadataValidator(Validator):
             response = self._make_request(publication_url)
             if response.status_code == 403:
                 self._check_rxiv_url(publication_url)
-            response.raise_for_status()
+            else:
+                response.raise_for_status()
         except Exception:
             self.errors.append(f"Bad Publication URL '{publication_url}'.")
 
@@ -91,9 +92,18 @@ class PublicationMetadataValidator(Validator):
                 doi_regex = r"10.+\/.*"
                 if match := re.search(doi_regex, split_url.path):
                     response = self._make_request(urljoin(url_prefix, match[0]))
+                    url = urljoin(url_prefix, match[0])
+                    response = self._make_request(url)
                     if messages := response.json().get("messages"):
-                        if not messages[0].get("status") == "ok":
+                        print(response.json())
+                        if messages[0].get("status") == "DOI not recognizable":
+                            self.errors.append(
+                                f"{rxiv} API search failed. Check that DOI does not have appended data, e.g. version string."
+                            )
+                        elif not messages[0].get("status") == "ok":
                             self.errors.append(f"Failed {rxiv} API search: {url}.")
+            else:
+                self.errors.append(f"403: Access forbidden for Publication URL {url}")
 
     def _check_doi(self):
         """
@@ -105,6 +115,9 @@ class PublicationMetadataValidator(Validator):
         }.items():
             if not doi:
                 return
+            elif doi.startswith("http"):
+                self.errors.append(f"{doi_type} should not be in URL form: {doi}")
+                return
             try:
                 response = self._make_request(f"https://www.doi.org/{doi}")
                 if response.status_code == 403:
@@ -114,7 +127,8 @@ class PublicationMetadataValidator(Validator):
                     response = self._make_request(
                         f"https://api.crossref.org/works/doi/{doi}?mailto=help@hubmapconsortium.org"
                     )
-                response.raise_for_status()
+                else:
+                    response.raise_for_status()
             except Exception:
                 self.errors.append(f"Bad {doi_type} '{doi}'.")
 

--- a/src/ingest_validation_tests/publication_metadata_validator.py
+++ b/src/ingest_validation_tests/publication_metadata_validator.py
@@ -105,8 +105,6 @@ class PublicationMetadataValidator(Validator):
                             )
                         elif not messages[0].get("status") == "ok":
                             self.errors.append(f"Failed {rxiv} API search: {url}.")
-            else:
-                self.errors.append(f"403: Access forbidden for Publication URL {url}")
 
     def _check_doi(self):
         """

--- a/src/ingest_validation_tests/publication_metadata_validator.py
+++ b/src/ingest_validation_tests/publication_metadata_validator.py
@@ -20,6 +20,7 @@ class PublicationMetadataValidator(Validator):
     def __init__(self, base_paths, assay_type, *args, **kwargs):
         super().__init__(base_paths, assay_type, *args, **kwargs)
         self.errors: list = []
+        self.supported_rxivs = ["biorxiv", "medrxiv"]
 
     def _collect_errors(self) -> list[str | None]:
         self.check_required()
@@ -71,7 +72,9 @@ class PublicationMetadataValidator(Validator):
         publication_url = self.entity_data.get("publication_url", "")
         try:
             response = self._make_request(publication_url)
-            if response.status_code == 403:
+            if response.status_code == 403 and any(
+                [rxiv in publication_url for rxiv in self.supported_rxivs]
+            ):
                 self._check_rxiv_url(publication_url)
             else:
                 response.raise_for_status()
@@ -84,7 +87,7 @@ class PublicationMetadataValidator(Validator):
         and try to check using biorxiv API.
         """
         split_url = urlsplit(url)
-        for rxiv in ["biorxiv", "medrxiv"]:
+        for rxiv in self.supported_rxivs:
             if rxiv in split_url.netloc:
                 url_prefix = f"https://api.biorxiv.org/details/{rxiv}/"
                 # theoretically a DOI could start with a digit other than 10 but not yet
@@ -98,7 +101,7 @@ class PublicationMetadataValidator(Validator):
                         print(response.json())
                         if messages[0].get("status") == "DOI not recognizable":
                             self.errors.append(
-                                f"{rxiv} API search failed. Check that DOI does not have appended data, e.g. version string."
+                                f"{rxiv} API search failed. Check that DOI does not have appended data, e.g. version string: {url}"
                             )
                         elif not messages[0].get("status") == "ok":
                             self.errors.append(f"Failed {rxiv} API search: {url}.")

--- a/src/ingest_validation_tests/publication_metadata_validator.py
+++ b/src/ingest_validation_tests/publication_metadata_validator.py
@@ -1,6 +1,7 @@
 import os
+import re
 from functools import cached_property
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlsplit
 
 import requests
 from validator import Validator
@@ -63,28 +64,62 @@ class PublicationMetadataValidator(Validator):
                 )
 
     def check_urls(self):
+        self._check_publication_url()
+        self._check_doi()
+
+    def _check_publication_url(self):
         publication_url = self.entity_data.get("publication_url", "")
         try:
-            self._make_request(publication_url)
+            response = self._make_request(publication_url)
+            if response.status_code == 403:
+                self._check_rxiv_url(publication_url)
+            response.raise_for_status()
         except Exception:
             self.errors.append(f"Bad Publication URL '{publication_url}'.")
-        for doi_data in [
-            [self.entity_data.get("publication_doi", ""), "Publication DOI"],
-            [self.entity_data.get("omap_doi", ""), "OMAP DOI"],
-        ]:
-            self._check_doi(*doi_data)
 
-    def _check_doi(self, doi: str, doi_type: str):
-        if not doi:
-            return
-        try:
-            self._make_request(f"https://doi.org/{doi}")
-        except Exception:
-            self.errors.append(f"Bad {doi_type} '{doi}'.")
+    def _check_rxiv_url(self, url):
+        """
+        Automated requests are blocked by biorxiv; parse URL
+        and try to check using biorxiv API.
+        """
+        split_url = urlsplit(url)
+        for rxiv in ["biorxiv", "medrxiv"]:
+            if rxiv in split_url.netloc:
+                url_prefix = f"https://api.biorxiv.org/details/{rxiv}/"
+                # theoretically a DOI could start with a digit other than 10 but not yet
+                # https://www.doi.org/doi-handbook/html/index.html as of 04/2026
+                doi_regex = r"10.+\/.*"
+                if match := re.search(doi_regex, split_url.path):
+                    response = self._make_request(urljoin(url_prefix, match[0]))
+                    if messages := response.json().get("messages"):
+                        if not messages[0].get("status") == "ok":
+                            self.errors.append(f"Failed {rxiv} API search: {url}.")
 
-    def _make_request(self, url: str):
-        response = requests.get(url)
-        response.raise_for_status()
+    def _check_doi(self):
+        """
+        Check provided DOI string against doi.org, fallback to crossref API.
+        """
+        for doi_type, doi in {
+            "Publication DOI": self.entity_data.get("publication_doi"),
+            "OMAP DOI": self.entity_data.get("omap_doi"),
+        }.items():
+            if not doi:
+                return
+            try:
+                response = self._make_request(f"https://www.doi.org/{doi}")
+                if response.status_code == 403:
+                    # automated requests may be blocked, try crossref API
+                    # (widely adopted but not universal, which is why we try
+                    # doi.org first); mailto included for "polite mode"
+                    response = self._make_request(
+                        f"https://api.crossref.org/works/doi/{doi}?mailto=help@hubmapconsortium.org"
+                    )
+                response.raise_for_status()
+            except Exception:
+                self.errors.append(f"Bad {doi_type} '{doi}'.")
+
+    def _make_request(self, url: str) -> requests.Response:
+        return requests.get(url)
 
     @property
     def ingest_ui_link(self) -> str:

--- a/src/ingest_validation_tests/publication_metadata_validator.py
+++ b/src/ingest_validation_tests/publication_metadata_validator.py
@@ -72,10 +72,13 @@ class PublicationMetadataValidator(Validator):
         publication_url = self.entity_data.get("publication_url", "")
         try:
             response = self._make_request(publication_url)
-            if response.status_code == 403 and any(
-                [rxiv in publication_url for rxiv in self.supported_rxivs]
-            ):
-                self._check_rxiv_url(publication_url)
+            if response.status_code == 403:
+                if any([rxiv in publication_url for rxiv in self.supported_rxivs]):
+                    self._check_rxiv_url(publication_url)
+                else:
+                    self.errors.append(
+                        f"403: Access forbidden for Publication URL {publication_url}"
+                    )
             else:
                 response.raise_for_status()
         except Exception:
@@ -95,8 +98,6 @@ class PublicationMetadataValidator(Validator):
                 doi_regex = r"10.+\/.*"
                 if match := re.search(doi_regex, split_url.path):
                     response = self._make_request(urljoin(url_prefix, match[0]))
-                    url = urljoin(url_prefix, match[0])
-                    response = self._make_request(url)
                     if messages := response.json().get("messages"):
                         print(response.json())
                         if messages[0].get("status") == "DOI not recognizable":

--- a/src/ingest_validation_tests/qptiff_channel_validator.py
+++ b/src/ingest_validation_tests/qptiff_channel_validator.py
@@ -109,12 +109,12 @@ class QpTiffChannelValidator(Validator):
         channels_list = channels.iloc[:, 0].tolist()
         qptf_channels = self._get_qptiff_channels(qptiff_file)
         channels_list.sort()
-        channels_set = set(channels_list)
+        channels_set = set([str(channel) for channel in channels_list])
         if not channels_set == qptf_channels:
             self.errors.append(
                 f"""Channels in {self.rel_filename_str(channels_csv)} and {self.rel_filename_str(qptiff_file)} do not match.
                     Channels in CSV that are not present in QPTIFF: {', '.join(channels_set.difference(qptf_channels))}
-                    Channels in QPTIFF that are not present in CSV: {', '.join(qptf_channels.difference(channels_set))}
+                    Channels in QPTIFF that are not present in CSV: {', '.join(channels.difference(channels_set))}
                 """
             )
 
@@ -136,7 +136,7 @@ class QpTiffChannelValidator(Validator):
                         channel_name := ElementTree.fromstring(description).find("Name")
                     ) is not None:
                         qptf_channels.append(channel_name.text)
-        return set(sorted(qptf_channels))
+        return set(sorted([str(channel) for channel in qptf_channels]))
 
     def _get_parent_dir_paths(self, path) -> tuple[Path | None, Path | None]:
         channels_parent_path = Path(os.path.join(path, "lab_processed/images"))

--- a/tests/test_publication_metadata_validator.py
+++ b/tests/test_publication_metadata_validator.py
@@ -244,6 +244,18 @@ class TestPublicationMetadataValidator:
             f"https://api.crossref.org/works/doi/10/test?mailto=help@hubmapconsortium.org"
         )
 
+    def test_catch_url_doi(self, monkeypatch):
+        doi = "https://bad_doi"
+        with monkeypatch.context() as m:
+            m.setattr(
+                PublicationMetadataValidator,
+                "entity_data",
+                self.required_fields | {"publication_doi": doi},
+            )
+            v = PublicationMetadataValidator(*self.default_args, **self.default_kwargs)
+            v._check_doi()
+            assert v.errors == [f"Publication DOI should not be in URL form: {doi}"]
+
     def test_pub_url_parser(self, monkeypatch):
         test_url_value = "10.123/test"
         monkeypatch.setattr(

--- a/tests/test_publication_metadata_validator.py
+++ b/tests/test_publication_metadata_validator.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock
+from unittest.mock import Mock, call
 
 import pytest
 import requests
@@ -230,6 +230,25 @@ class TestPublicationMetadataValidator:
             "Bad OMAP DOI 'omap_doi_bad_value'.",
         ]
 
+    def test_doi_normal_path(self, monkeypatch):
+        monkeypatch.setattr(
+            PublicationMetadataValidator,
+            "entity_data",
+            self.required_fields | {"publication_doi": "10/test", "omap_doi": "omap_doi"},
+        )
+        mock_response = Mock(return_value=self.get_mock_response("", 200))
+        monkeypatch.setattr(PublicationMetadataValidator, "_make_request", mock_response)
+        v = PublicationMetadataValidator(*self.default_args, **self.default_kwargs)
+        v._check_doi()
+        mock_response.assert_has_calls(
+            [call("https://www.doi.org/10/test"), call("https://www.doi.org/omap_doi")]
+        )
+        assert (
+            call("https://api.crossref.org/works/doi/10/test?mailto=help@hubmapconsortium.org")
+            not in mock_response.call_args_list
+        )
+        assert not v.errors
+
     def test_doi_fallback_activates(self, monkeypatch):
         monkeypatch.setattr(
             PublicationMetadataValidator,
@@ -256,7 +275,23 @@ class TestPublicationMetadataValidator:
             v._check_doi()
             assert v.errors == [f"Publication DOI should not be in URL form: {doi}"]
 
-    def test_pub_url_parser(self, monkeypatch):
+    def test_pub_url_normal_path(self, monkeypatch):
+        monkeypatch.setattr(
+            PublicationMetadataValidator,
+            "entity_data",
+            self.required_fields | {"publication_url": f"i_am_good_url"},
+        )
+        mock_response = Mock(return_value=self.get_mock_response("", 200))
+        mock_rxiv = Mock()
+        monkeypatch.setattr(PublicationMetadataValidator, "_make_request", mock_response)
+        monkeypatch.setattr(PublicationMetadataValidator, "_check_rxiv_url", mock_rxiv)
+        v = PublicationMetadataValidator(*self.default_args, **self.default_kwargs)
+        v._check_publication_url()
+        mock_response.assert_called_with(f"i_am_good_url")
+        mock_rxiv.assert_not_called()
+        assert not v.errors
+
+    def test_pub_url_parser_403_rxiv(self, monkeypatch):
         test_url_value = "10.123/test"
         monkeypatch.setattr(
             PublicationMetadataValidator,
@@ -271,3 +306,16 @@ class TestPublicationMetadataValidator:
         mock_response.assert_called_with(
             f"https://api.biorxiv.org/details/biorxiv/{test_url_value}"
         )
+
+    def test_pub_url_parser_403_other(self, monkeypatch):
+        url = "www.test.com"
+        monkeypatch.setattr(
+            PublicationMetadataValidator,
+            "entity_data",
+            self.required_fields | {"publication_url": url},
+        )
+        mock_response = Mock(return_value=self.get_mock_response("", 403))
+        monkeypatch.setattr(PublicationMetadataValidator, "_make_request", mock_response)
+        v = PublicationMetadataValidator(*self.default_args, **self.default_kwargs)
+        v._check_publication_url()
+        assert v.errors == [f"403: Access forbidden for Publication URL {url}"]

--- a/tests/test_publication_metadata_validator.py
+++ b/tests/test_publication_metadata_validator.py
@@ -1,4 +1,7 @@
+from unittest.mock import Mock
+
 import pytest
+import requests
 from publication_metadata_validator import PublicationMetadataValidator
 
 
@@ -32,9 +35,13 @@ class TestPublicationMetadataValidator:
     }
 
     @staticmethod
-    def mock_raise(url):
+    def get_mock_response(url: str, status_code: int = 200, response_data: bytes = b""):
         if "bad" in url:
-            raise Exception
+            status_code = 404
+        mock_resp = requests.models.Response()
+        mock_resp.status_code = status_code
+        mock_resp._content = response_data
+        return mock_resp
 
     @pytest.fixture
     def _mock_validator_good(self, monkeypatch):
@@ -42,13 +49,17 @@ class TestPublicationMetadataValidator:
         monkeypatch.setattr(PublicationMetadataValidator, "entity_data", self.required_fields)
         monkeypatch.setattr(PublicationMetadataValidator, "uuid", "test_uuid")
         monkeypatch.setattr(
-            PublicationMetadataValidator, "_make_request", lambda a, url: self.mock_raise(url)
+            PublicationMetadataValidator,
+            "_make_request",
+            lambda _, url: self.get_mock_response(url),
         )
 
     def test_collect_errors(self, monkeypatch):
         with monkeypatch.context() as m:
             m.setattr(
-                PublicationMetadataValidator, "_make_request", lambda a, url: self.mock_raise(url)
+                PublicationMetadataValidator,
+                "_make_request",
+                lambda _, url: self.get_mock_response(url),
             )
             m.setattr(
                 PublicationMetadataValidator,
@@ -218,3 +229,33 @@ class TestPublicationMetadataValidator:
             "Bad Publication DOI 'pub_doi_bad_value'.",
             "Bad OMAP DOI 'omap_doi_bad_value'.",
         ]
+
+    def test_doi_fallback_activates(self, monkeypatch):
+        monkeypatch.setattr(
+            PublicationMetadataValidator,
+            "entity_data",
+            self.required_fields | {"publication_doi": "10/test", "omap_doi": None},
+        )
+        mock_response = Mock(return_value=self.get_mock_response("", 403))
+        monkeypatch.setattr(PublicationMetadataValidator, "_make_request", mock_response)
+        v = PublicationMetadataValidator(*self.default_args, **self.default_kwargs)
+        v._check_doi()
+        mock_response.assert_called_with(
+            f"https://api.crossref.org/works/doi/10/test?mailto=help@hubmapconsortium.org"
+        )
+
+    def test_pub_url_parser(self, monkeypatch):
+        test_url_value = "10.123/test"
+        monkeypatch.setattr(
+            PublicationMetadataValidator,
+            "entity_data",
+            self.required_fields
+            | {"publication_url": f"https://www.biorxiv.org/content/{test_url_value}"},
+        )
+        mock_response = Mock(return_value=self.get_mock_response("", 403))
+        monkeypatch.setattr(PublicationMetadataValidator, "_make_request", mock_response)
+        v = PublicationMetadataValidator(*self.default_args, **self.default_kwargs)
+        v._check_publication_url()
+        mock_response.assert_called_with(
+            f"https://api.biorxiv.org/details/biorxiv/{test_url_value}"
+        )


### PR DESCRIPTION
Dealing with 403s from e.g. Cloudflare that block our automated checks.
- Route DOI requests that fail with a 403 to Crossref API (doi.org should have comprehensive coverage so we still want to start there)
- Route Publication URL requests that fail with a 403 to special-cased biorxiv/medrxiv logic
- Informative errors for:
     - biorxiv/medrxiv DOI is bad (likely due to versioning in the submitted URL)
     - non-rxiv 403s
     - DOIs that are in URL form rather than DOI string form

Also:
- Bugfix: do not assume that QPTIFF channels are strings
- Added tests