### PR TITLE
QPTIFF shared upload support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ jsonschema==4.23.0
 pandas==2.2.3
 python-frontmatter>=1.1.0
 requests==2.32.3
-tifffile==2024.6.18
+tifffile==2021.11.2
 xmlschema==3.4.5

--- a/src/ingest_validation_tests/qptiff_channel_validator.py
+++ b/src/ingest_validation_tests/qptiff_channel_validator.py
@@ -1,6 +1,7 @@
 import os
 import re
 import subprocess
+from collections import defaultdict
 from functools import cached_property
 from multiprocessing import Pool
 from pathlib import Path
@@ -84,66 +85,79 @@ class QpTiffChannelValidator(Validator):
             if not (channel_csv and qptiff_file):
                 continue
             files_to_test[path] = {"csv": channel_csv, "qptiff": qptiff_file}
-
         return files_to_test
 
-    def _get_shared_upload_file_pairs(self, base_path: Path) -> dict:
+    def _get_shared_upload_file_pairs(self, base_path: Path) -> dict[int, dict[str, Path]]:
         """
         non_global directory may contain multiple raw/images/.*qptiff
         and lab_processed/images/.*channels.csv files.
         Read the non_global_paths field of the metadata.tsv and retrieve
         files from there. Check global directory if not found.
-        Return {"data_path": {"csv": qptiff.channels.csv, "qptiff": qptiff_file}}
+        If any rows are missing one or more files, log error and omit; test others.
+        Return {<data_row>: {"csv": qptiff.channels.csv, "qptiff": qptiff_file}}
         """
         if not self.schema_rows:
             raise Exception("Row data from metadata.tsv is required to validate shared uploads.")
-        files = {}
-        # check non_global files identified in metadata.tsv
-        non_global_paths = get_non_global_paths_by_row(self.schema_rows, base_path)
-        for data_path, row_paths in non_global_paths.items():
-            # find qptiff and channels files in non_global/
-            qptiff_paths = [
-                Path(base_path / path)
-                for path in row_paths
-                if re.search(r"raw\/images\/[^\/]*qptiff", str(path))
-            ]
-            channel_paths = [
-                Path(base_path / path)
-                for path in row_paths
-                if re.search(r"lab_processed\/images\/.*channels\.csv", str(path))
-            ]
+        files = defaultdict(dict)
+        # check non_global files identified in metadata.tsv; return if any do not exist
+        try:
+            non_global_paths = get_non_global_paths_by_row(self.schema_rows, base_path)
+        except Exception as e:
+            self.errors.append(str(e))
+            return {}
+        # find files in non_global/
+        for row_num, row_paths in non_global_paths.items():
+            for file_type, regex in {
+                "csv": r"lab_processed\/images\/.*channels\.csv",
+                "qptiff": r"raw\/images\/[^\/]*qptiff",
+            }.items():
+                paths_for_type = [Path(path) for path in row_paths if re.search(regex, str(path))]
+                files[row_num][file_type] = paths_for_type
+        # fill in any missing files or log errors
+        all_files = self._shared_upload_find_missing(files, base_path)
+        return all_files
 
-            # if files are not found, check in global/
-            qptiff_glob = "raw/images/*qptiff"
-            channels_glob = "lab_processed/images/*channels.csv"
-            if len(qptiff_paths) == 0:
-                qptiff_paths = [file for file in Path(base_path / "global").glob(qptiff_glob)]
-            if len(channel_paths) == 0:
-                channel_paths = [file for file in Path(base_path / "global").glob(channels_glob)]
+    def _shared_upload_find_missing(
+        self, non_global_files: dict[int, dict[str, list]], base_path: Path
+    ) -> dict[int, dict[str, Path]]:
+        """
+        After finding files in non_global_files, check for any incomplete file pairs.
+        Fill in values from /global if present, otherwise log error.
+        """
+        all_files = {}
+        for row, files_dict in non_global_files.items():
+            csv_path = self._check_global(
+                "csv",
+                "lab_processed/images/*channels.csv",
+                files_dict.get("csv", []),
+                base_path,
+                row,
+            )
+            qptiff_path = self._check_global(
+                "qptiff", "raw/images/*qptiff", files_dict.get("qptiff", []), base_path, row
+            )
+            if csv_path and qptiff_path:
+                all_files[row] = {"csv": csv_path, "qptiff": qptiff_path}
+        return all_files
 
-            # there should be exactly one of each, but if not, log error with found files and continue to next path
-            if len(qptiff_paths) != 1 or len(channel_paths) != 1:
-                qptiff_paths_str = (
-                    f"({', '.join([self.rel_filename_str(path) for path in qptiff_paths])}) "
-                    if qptiff_paths
-                    else ""
-                )
-                channel_paths_str = (
-                    f"({', '.join([self.rel_filename_str(path) for path in channel_paths])}) "
-                    if channel_paths
-                    else ""
-                )
+    def _check_global(
+        self, file_type: str, file_glob: str, files_list: list[Path], base_path: Path, row: int
+    ) -> Path | None:
+        if not files_list:
+            # files have not been found, check in global/
+            if not (files_list := [file for file in Path(base_path / "global").glob(file_glob)]):
                 self.errors.append(
-                    f"Found {len(qptiff_paths)} qptiff(s) {qptiff_paths_str}and {len(channel_paths)} channels.csv(s) {channel_paths_str}for dataset {data_path} in shared upload."
+                    f"Unable to find {file_type} for dataset row {row} in shared upload."
                 )
-                continue
-
-            # make sure paths exist
-            for path in [channel_paths[0], qptiff_paths[0]]:
-                if not Path(path).exists():
-                    self.errors.append(f"Path {self.rel_filename_str(path)} doesn't exist.")
-            files[data_path] = {"csv": channel_paths[0], "qptiff": qptiff_paths[0]}
-        return files
+                return
+        if len(files_list) == 1:
+            # good, no further checks needed
+            return files_list[0]
+        # more than one path found, error
+        paths_str = ", ".join([self.rel_filename_str(path) for path in files_list])
+        self.errors.append(
+            f"Found {len(files_list)} {file_type}s ({paths_str}) for dataset in row {row} in shared upload."
+        )
 
     def _get_file_path(self, parent_path: Path, extension: str) -> Path | None:
         if not parent_path.exists():
@@ -175,7 +189,7 @@ class QpTiffChannelValidator(Validator):
 
         df = pd.read_csv(filename)
         # pipeline uses column position to determine channel & cell/nucleus segmentation
-        if column_order_errors := self.check_column_order(df, filename):
+        if column_order_errors := self._check_column_order(df, filename):
             # validation can't continue if columns out of order
             self.errors.extend(column_order_errors)
             return
@@ -186,7 +200,7 @@ class QpTiffChannelValidator(Validator):
                     f"{self.rel_filename_str(filename)} must have at least one 'Yes' value in column '{column}'"
                 )
 
-    def check_column_order(self, df: pd.DataFrame, filename: Path) -> list:
+    def _check_column_order(self, df: pd.DataFrame, filename: Path) -> list:
         column_order_errors = []
         for index, columns in enumerate(self.ordered_columns):
             try:

--- a/src/ingest_validation_tests/qptiff_channel_validator.py
+++ b/src/ingest_validation_tests/qptiff_channel_validator.py
@@ -96,53 +96,51 @@ class QpTiffChannelValidator(Validator):
         files from there. Check global directory if not found.
         Return {"data_path": {"csv": qptiff.channels.csv, "qptiff": qptiff_file}}
         """
-        if not self.schema or not self.schema.rows:
-            raise Exception(
-                "SchemaVersion with rows attribute is required to validate shared uploads."
-            )
+        if not self.schema_rows:
+            raise Exception("Row data from metadata.tsv is required to validate shared uploads.")
         files = {}
         # check non_global files identified in metadata.tsv
-        non_global_paths = get_non_global_paths_by_row(self.schema.rows)
+        non_global_paths = get_non_global_paths_by_row(self.schema_rows)
         for data_path, row_paths in non_global_paths.items():
-            # find qptiff and channels files in files list for row
-            qptiff_regex = r"raw\/images\/[^\/]*qptiff"
-            channels_regex = r"lab_processed\/images\/.*channels\.csv"
+            # find qptiff and channels files in non_global/
             qptiff_paths = [
-                Path(base_path / path) for path in row_paths if re.search(qptiff_regex, str(path))
+                Path(base_path / path)
+                for path in row_paths
+                if re.search(r"raw\/images\/[^\/]*qptiff", str(path))
             ]
             channels_paths = [
                 Path(base_path / path)
                 for path in row_paths
-                if re.search(channels_regex, str(path))
+                if re.search(r"lab_processed\/images\/.*channels\.csv", str(path))
             ]
 
+            # if files are not found, check in global/
+            qptiff_glob = "raw/images/*qptiff"
+            channels_glob = "lab_processed/images/*channels.csv"
             if len(qptiff_paths) == 0:
-                # try in global directory
-                qptiff_paths = [
-                    file for file in Path(base_path / "global").glob("raw/images/*qptiff")
-                ]
+                qptiff_paths = [file for file in Path(base_path / "global").glob(qptiff_glob)]
             if len(channels_paths) == 0:
-                # try in global directory
-                channels_paths = [
-                    file
-                    for file in Path(base_path / "global").glob(
-                        "lab_processed/images/*channels.csv"
-                    )
-                ]
-            # should be exactly one of each
+                channels_paths = [file for file in Path(base_path / "global").glob(channels_glob)]
+
+            # there should be exactly one of each, but if not...
             if len(qptiff_paths) != 1 or len(channels_paths) != 1:
-                self.errors.append(
-                    f"Found {len(qptiff_paths)} qptiffs and {len(channels_paths)} channels.csv paths for dataset {data_path} in shared upload."
-                )
+                # give descriptive error message if a file is in the wrong place
+                if bad_non_global_paths := self._get_error_for_bad_non_global_paths(
+                    (qptiff_paths, qptiff_glob), (channels_paths, channels_glob), base_path
+                ):
+                    for error in bad_non_global_paths:
+                        self.errors.append(error)
+                else:
+                    self.errors.append(
+                        f"Found {len(qptiff_paths)} qptiffs and {len(channels_paths)} channels.csv paths for dataset {data_path} in shared upload."
+                    )
                 continue
 
-            full_channel_path = channels_paths[0]
-            full_qptiff_path = qptiff_paths[0]
             # make sure paths exist
-            for path in [full_channel_path, full_qptiff_path]:
+            for path in [channels_paths[0], qptiff_paths[0]]:
                 if not Path(path).exists():
                     self.errors.append(f"Path {self.rel_filename_str(path)} doesn't exist.")
-            files[data_path] = {"csv": full_channel_path, "qptiff": full_qptiff_path}
+            files[data_path] = {"csv": channels_paths[0], "qptiff": qptiff_paths[0]}
         return files
 
     def _get_file_path(self, parent_path: Path, extension: str) -> Path | None:
@@ -161,6 +159,22 @@ class QpTiffChannelValidator(Validator):
             )
             return
         return files[0]
+
+    def _get_error_for_bad_non_global_paths(
+        self,
+        qptiff_pair: tuple[list[Path], str],
+        channels_paths: tuple[list[Path], str],
+        base_path: Path,
+    ) -> list[str]:
+        errors = []
+        for found_paths, filepath_glob in [qptiff_pair, channels_paths]:
+            if len(found_paths) == 0:
+                paths = [file for file in Path(base_path / "non_global").glob(filepath_glob)]
+                if paths:
+                    errors.append(
+                        f"File(s) {', '.join([self.rel_filename_str(path) for path in paths])} found but missing from non_global_files column in metadata.tsv."
+                    )
+        return errors
 
     ##################
     # CSV Validation #

--- a/src/ingest_validation_tests/qptiff_channel_validator.py
+++ b/src/ingest_validation_tests/qptiff_channel_validator.py
@@ -79,7 +79,6 @@ class QpTiffChannelValidator(Validator):
             if self.shared_upload:
                 files_to_test.update(self._get_shared_upload_file_pairs(path.parent))
                 break
-            # TODO: test case where files are all in non_global or global, and where files are mixed
             channel_csv = self._get_file_path(path / "lab_processed/images", ".channels.csv")
             qptiff_file = self._get_file_path(path / "raw/images", ".qptiff")
             if not (channel_csv and qptiff_file):
@@ -100,7 +99,7 @@ class QpTiffChannelValidator(Validator):
             raise Exception("Row data from metadata.tsv is required to validate shared uploads.")
         files = {}
         # check non_global files identified in metadata.tsv
-        non_global_paths = get_non_global_paths_by_row(self.schema_rows)
+        non_global_paths = get_non_global_paths_by_row(self.schema_rows, base_path)
         for data_path, row_paths in non_global_paths.items():
             # find qptiff and channels files in non_global/
             qptiff_paths = [
@@ -310,7 +309,7 @@ class Engine:
         except Exception as e:
             raise Exception(f"Error with {get_rel_filename_str(data_path, qptiff_path)}: {e}")
 
-    def extract_ome_xml(self, data_path: Path, qptiff_path) -> Path:
+    def extract_ome_xml(self, data_path: Path, qptiff_path: Path) -> Path:
         """
         The bioformats2raw params (except for no-tiles) are borrowed from the
         phenocycler pipeline (v1.4.8); major changes to how QPTIFFs are converted

--- a/src/ingest_validation_tests/qptiff_channel_validator.py
+++ b/src/ingest_validation_tests/qptiff_channel_validator.py
@@ -92,7 +92,7 @@ class QpTiffChannelValidator(Validator):
         non_global directory may contain multiple raw/images/.*qptiff
         and lab_processed/images/.*channels.csv files.
         Read the non_global_paths field of the metadata.tsv and retrieve
-        files from there. Fill with value from /global if not found.
+        files from there. Fill with value from global/ if not found.
         If any rows are missing one or more files, log error and omit; test others.
         Return {<data_row>: {"csv": qptiff.channels.csv, "qptiff": qptiff_file}}
         """
@@ -137,6 +137,7 @@ class QpTiffChannelValidator(Validator):
         ]
         qptiff_list = [file for file in Path(base_path / "global").glob("raw/images/*qptiff")]
         for file_type, file_list in {"csv": csv_list, "qptiff": qptiff_list}.items():
+            # should not be more than one of each file
             if len(file_list) > 1:
                 paths_str = ", ".join([self.rel_filename_str(path) for path in csv_list])
                 errors.append(f"Found {len(file_list)} global {file_type}s ({paths_str}).")

--- a/src/ingest_validation_tests/qptiff_channel_validator.py
+++ b/src/ingest_validation_tests/qptiff_channel_validator.py
@@ -107,7 +107,7 @@ class QpTiffChannelValidator(Validator):
                 for path in row_paths
                 if re.search(r"raw\/images\/[^\/]*qptiff", str(path))
             ]
-            channels_paths = [
+            channel_paths = [
                 Path(base_path / path)
                 for path in row_paths
                 if re.search(r"lab_processed\/images\/.*channels\.csv", str(path))
@@ -118,28 +118,31 @@ class QpTiffChannelValidator(Validator):
             channels_glob = "lab_processed/images/*channels.csv"
             if len(qptiff_paths) == 0:
                 qptiff_paths = [file for file in Path(base_path / "global").glob(qptiff_glob)]
-            if len(channels_paths) == 0:
-                channels_paths = [file for file in Path(base_path / "global").glob(channels_glob)]
+            if len(channel_paths) == 0:
+                channel_paths = [file for file in Path(base_path / "global").glob(channels_glob)]
 
-            # there should be exactly one of each, but if not...
-            if len(qptiff_paths) != 1 or len(channels_paths) != 1:
-                # give descriptive error message if a file is in the wrong place
-                if bad_non_global_paths := self._get_error_for_bad_non_global_paths(
-                    (qptiff_paths, qptiff_glob), (channels_paths, channels_glob), base_path
-                ):
-                    for error in bad_non_global_paths:
-                        self.errors.append(error)
-                else:
-                    self.errors.append(
-                        f"Found {len(qptiff_paths)} qptiffs and {len(channels_paths)} channels.csv paths for dataset {data_path} in shared upload."
-                    )
+            # there should be exactly one of each, but if not, log error with found files and continue to next path
+            if len(qptiff_paths) != 1 or len(channel_paths) != 1:
+                qptiff_paths_str = (
+                    f"({', '.join([self.rel_filename_str(path) for path in qptiff_paths])}) "
+                    if qptiff_paths
+                    else ""
+                )
+                channel_paths_str = (
+                    f"({', '.join([self.rel_filename_str(path) for path in channel_paths])}) "
+                    if channel_paths
+                    else ""
+                )
+                self.errors.append(
+                    f"Found {len(qptiff_paths)} qptiff(s) {qptiff_paths_str}and {len(channel_paths)} channels.csv(s) {channel_paths_str}for dataset {data_path} in shared upload."
+                )
                 continue
 
             # make sure paths exist
-            for path in [channels_paths[0], qptiff_paths[0]]:
+            for path in [channel_paths[0], qptiff_paths[0]]:
                 if not Path(path).exists():
                     self.errors.append(f"Path {self.rel_filename_str(path)} doesn't exist.")
-            files[data_path] = {"csv": channels_paths[0], "qptiff": qptiff_paths[0]}
+            files[data_path] = {"csv": channel_paths[0], "qptiff": qptiff_paths[0]}
         return files
 
     def _get_file_path(self, parent_path: Path, extension: str) -> Path | None:
@@ -158,22 +161,6 @@ class QpTiffChannelValidator(Validator):
             )
             return
         return files[0]
-
-    def _get_error_for_bad_non_global_paths(
-        self,
-        qptiff_pair: tuple[list[Path], str],
-        channels_paths: tuple[list[Path], str],
-        base_path: Path,
-    ) -> list[str]:
-        errors = []
-        for found_paths, filepath_glob in [qptiff_pair, channels_paths]:
-            if len(found_paths) == 0:
-                paths = [file for file in Path(base_path / "non_global").glob(filepath_glob)]
-                if paths:
-                    errors.append(
-                        f"File(s) {', '.join([self.rel_filename_str(path) for path in paths])} found but missing from non_global_files column in metadata.tsv."
-                    )
-        return errors
 
     ##################
     # CSV Validation #

--- a/src/ingest_validation_tests/qptiff_channel_validator.py
+++ b/src/ingest_validation_tests/qptiff_channel_validator.py
@@ -1,4 +1,5 @@
 import os
+import re
 import subprocess
 from functools import cached_property
 from multiprocessing import Pool
@@ -7,7 +8,7 @@ from textwrap import dedent
 
 import pandas as pd
 import xmlschema
-from validator import Validator, get_rel_filename_str
+from validator import Validator, get_non_global_paths_by_row, get_rel_filename_str
 
 # pipeline uses 0.9.2 but that does not include no-tiles arg
 BIOFORMATS2RAW_RELEASE = "0.10.0"
@@ -36,6 +37,9 @@ class QpTiffChannelValidator(Validator):
 
     def __init__(self, base_paths, assay_type, *args, **kwargs):
         super().__init__(base_paths, assay_type, *args, **kwargs)
+        self.shared_upload = any(
+            [bool(path.stem in ["global", "non_global"]) for path in self.paths]
+        )
         self.errors = []
 
     def _collect_errors(self) -> list[str | None]:
@@ -72,6 +76,10 @@ class QpTiffChannelValidator(Validator):
         files_to_test = {}
 
         for path in self.paths:
+            if self.shared_upload:
+                files_to_test.update(self._get_shared_upload_file_pairs(path.parent))
+                break
+            # TODO: test case where files are all in non_global or global, and where files are mixed
             channel_csv = self._get_file_path(path / "lab_processed/images", ".channels.csv")
             qptiff_file = self._get_file_path(path / "raw/images", ".qptiff")
             if not (channel_csv and qptiff_file):
@@ -79,6 +87,63 @@ class QpTiffChannelValidator(Validator):
             files_to_test[path] = {"csv": channel_csv, "qptiff": qptiff_file}
 
         return files_to_test
+
+    def _get_shared_upload_file_pairs(self, base_path: Path) -> dict:
+        """
+        non_global directory may contain multiple raw/images/.*qptiff
+        and lab_processed/images/.*channels.csv files.
+        Read the non_global_paths field of the metadata.tsv and retrieve
+        files from there. Check global directory if not found.
+        Return {"data_path": {"csv": qptiff.channels.csv, "qptiff": qptiff_file}}
+        """
+        if not self.schema or not self.schema.rows:
+            raise Exception(
+                "SchemaVersion with rows attribute is required to validate shared uploads."
+            )
+        files = {}
+        # check non_global files identified in metadata.tsv
+        non_global_paths = get_non_global_paths_by_row(self.schema.rows)
+        for data_path, row_paths in non_global_paths.items():
+            # find qptiff and channels files in files list for row
+            qptiff_regex = r"raw\/images\/[^\/]*qptiff"
+            channels_regex = r"lab_processed\/images\/.*channels\.csv"
+            qptiff_paths = [
+                Path(base_path / path) for path in row_paths if re.search(qptiff_regex, str(path))
+            ]
+            channels_paths = [
+                Path(base_path / path)
+                for path in row_paths
+                if re.search(channels_regex, str(path))
+            ]
+
+            if len(qptiff_paths) == 0:
+                # try in global directory
+                qptiff_paths = [
+                    file for file in Path(base_path / "global").glob("raw/images/*qptiff")
+                ]
+            if len(channels_paths) == 0:
+                # try in global directory
+                channels_paths = [
+                    file
+                    for file in Path(base_path / "global").glob(
+                        "lab_processed/images/*channels.csv"
+                    )
+                ]
+            # should be exactly one of each
+            if len(qptiff_paths) != 1 or len(channels_paths) != 1:
+                self.errors.append(
+                    f"Found {len(qptiff_paths)} qptiffs and {len(channels_paths)} channels.csv paths for dataset {data_path} in shared upload."
+                )
+                continue
+
+            full_channel_path = channels_paths[0]
+            full_qptiff_path = qptiff_paths[0]
+            # make sure paths exist
+            for path in [full_channel_path, full_qptiff_path]:
+                if not Path(path).exists():
+                    self.errors.append(f"Path {self.rel_filename_str(path)} doesn't exist.")
+            files[data_path] = {"csv": full_channel_path, "qptiff": full_qptiff_path}
+        return files
 
     def _get_file_path(self, parent_path: Path, extension: str) -> Path | None:
         if not parent_path.exists():

--- a/src/ingest_validation_tests/qptiff_channel_validator.py
+++ b/src/ingest_validation_tests/qptiff_channel_validator.py
@@ -92,72 +92,85 @@ class QpTiffChannelValidator(Validator):
         non_global directory may contain multiple raw/images/.*qptiff
         and lab_processed/images/.*channels.csv files.
         Read the non_global_paths field of the metadata.tsv and retrieve
-        files from there. Check global directory if not found.
+        files from there. Fill with value from /global if not found.
         If any rows are missing one or more files, log error and omit; test others.
         Return {<data_row>: {"csv": qptiff.channels.csv, "qptiff": qptiff_file}}
         """
         if not self.schema_rows:
             raise Exception("Row data from metadata.tsv is required to validate shared uploads.")
-        files = defaultdict(dict)
-        # check non_global files identified in metadata.tsv; return if any do not exist
+        non_global_files = defaultdict(dict)
         try:
+            # get global values
+            global_files = self._shared_upload_get_global_files(base_path)
+            # retrieve non_global files identified in metadata.tsv
             non_global_paths = get_non_global_paths_by_row(self.schema_rows, base_path)
         except Exception as e:
+            # if too many global files or any expected non_global path not found, return
             self.errors.append(str(e))
             return {}
-        # find files in non_global/
+        # find relevant files in non_global/
         for row_num, row_paths in non_global_paths.items():
             for file_type, regex in {
                 "csv": r"lab_processed\/images\/.*channels\.csv",
                 "qptiff": r"raw\/images\/[^\/]*qptiff",
             }.items():
                 paths_for_type = [Path(path) for path in row_paths if re.search(regex, str(path))]
-                files[row_num][file_type] = paths_for_type
-        # fill in any missing files or log errors
-        all_files = self._shared_upload_find_missing(files, base_path)
-        return all_files
-
-    def _shared_upload_find_missing(
-        self, non_global_files: dict[int, dict[str, list]], base_path: Path
-    ) -> dict[int, dict[str, Path]]:
-        """
-        After finding files in non_global_files, check for any incomplete file pairs.
-        Fill in values from /global if present, otherwise log error.
-        """
+                non_global_files[row_num][file_type] = paths_for_type
+        # fill in any missing files with global values or log errors
         all_files = {}
         for row, files_dict in non_global_files.items():
-            csv_path = self._check_global(
-                "csv",
-                "lab_processed/images/*channels.csv",
-                files_dict.get("csv", []),
-                base_path,
-                row,
-            )
-            qptiff_path = self._check_global(
-                "qptiff", "raw/images/*qptiff", files_dict.get("qptiff", []), base_path, row
-            )
-            if csv_path and qptiff_path:
-                all_files[row] = {"csv": csv_path, "qptiff": qptiff_path}
+            if (
+                csv := self._fill_missing("csv", global_files["csv"], files_dict["csv"], row)
+            ) and (
+                qptiff := self._fill_missing(
+                    "qptiff", global_files["qptiff"], files_dict["qptiff"], row
+                )
+            ):
+                # only include dataset rows with both values; omitted rows will log errors
+                all_files[row] = {"csv": csv, "qptiff": qptiff}
         return all_files
 
-    def _check_global(
-        self, file_type: str, file_glob: str, files_list: list[Path], base_path: Path, row: int
+    def _shared_upload_get_global_files(self, base_path: Path) -> dict[str, Path | None]:
+        errors = []
+        csv_list = [
+            file for file in Path(base_path / "global").glob("lab_processed/images/*channels.csv")
+        ]
+        qptiff_list = [file for file in Path(base_path / "global").glob("raw/images/*qptiff")]
+        for file_type, file_list in {"csv": csv_list, "qptiff": qptiff_list}.items():
+            if len(file_list) > 1:
+                paths_str = ", ".join([self.rel_filename_str(path) for path in csv_list])
+                errors.append(f"Found {len(file_list)} global {file_type}s ({paths_str}).")
+        if errors:
+            raise Exception(" ".join(errors))
+        return {
+            "csv": csv_list[0] if csv_list else None,
+            "qptiff": qptiff_list[0] if qptiff_list else None,
+        }
+
+    def _fill_missing(
+        self,
+        file_type: str,
+        global_file: Path | None,
+        files_list: list[Path],
+        row: int,
     ) -> Path | None:
-        if not files_list:
-            # files have not been found, check in global/
-            if not (files_list := [file for file in Path(base_path / "global").glob(file_glob)]):
-                self.errors.append(
-                    f"Unable to find {file_type} for dataset row {row} in shared upload."
-                )
-                return
         if len(files_list) == 1:
-            # good, no further checks needed
+            # already correct, return single path
             return files_list[0]
-        # more than one path found, error
-        paths_str = ", ".join([self.rel_filename_str(path) for path in files_list])
-        self.errors.append(
-            f"Found {len(files_list)} {file_type}s ({paths_str}) for dataset in row {row} in shared upload."
-        )
+        if not files_list:
+            # no paths found, fill from global if possible or log error
+            if global_file:
+                return global_file
+            else:
+                self.errors.append(
+                    f"Unable to find {file_type} file for dataset row {row} in shared upload."
+                )
+        elif len(files_list) > 1:
+            # more than one path found, error
+            paths_str = ", ".join([self.rel_filename_str(path) for path in files_list])
+            self.errors.append(
+                f"Found {len(files_list)} {file_type}s ({paths_str}) for dataset in row {row} in shared upload."
+            )
 
     def _get_file_path(self, parent_path: Path, extension: str) -> Path | None:
         if not parent_path.exists():

--- a/src/ingest_validation_tests/segmentation_mask_imagesize_validation.py
+++ b/src/ingest_validation_tests/segmentation_mask_imagesize_validation.py
@@ -51,11 +51,11 @@ class ImageSizeValidator(Validator):
     ]
 
     def _collect_errors(self) -> list[str | None]:
-        if not self.schema:
-            return ["No schema found."]
+        if not self.schema_rows:
+            return ["No metadata rows found."]
         files_tested = False
         output = []
-        for row in self.schema.rows:
+        for row in self.schema_rows:
             filenames_to_test = []
             parent_filenames_to_test = []
             try:

--- a/src/ingest_validation_tests/validator.py
+++ b/src/ingest_validation_tests/validator.py
@@ -127,7 +127,7 @@ class Validator:
             print(message)
             return message
 
-    def rel_filename_str(self, filename: Path):
+    def rel_filename_str(self, filename: Path) -> str:
         return get_rel_filename_str(self.paths[0], filename)
 
     @property
@@ -141,19 +141,27 @@ class Validator:
 def get_non_global_paths_by_row(rows: list[dict], base_path: Path) -> dict[str | int, str]:
     """
     Create dict of non-global paths by row for a shared upload.
-    {<data_path_1>: [<path_1>, <path_2>], <data_path_2>: [<path_3>, <path_4>]}
+    {<row_index_0>: [<path_1>, <path_2>], <row_index_1>: [<path_3>, <path_4>]}
+    Return only if all paths exist, else raise.
     """
     files_by_row = {}
-    for row in rows:
+    errors = []
+    for i, row in enumerate(rows):
+        files = []
         non_global_files = row.get("non_global_files", "")
-        # data_path is not a real path, but is necessary to distinguish files per dataset
-        data_path = row["data_path"]
-        if data_path in [".", "./"]:
-            data_path = base_path
-        key = data_path
-        files_by_row[key] = [
-            Path(f"non_global/{file.strip()}") for file in non_global_files.split(";")
+        filepaths = [
+            Path(base_path / f"non_global/{file.strip()}") for file in non_global_files.split(";")
         ]
+        for file in filepaths:
+            if not file.exists():
+                errors.append(get_rel_filename_str(base_path, file))
+            else:
+                files.append(file)
+        files_by_row[i] = files
+    if errors:
+        raise Exception(
+            f"Files listed in non_global_files field do not exist: {', '.join(errors)}"
+        )
     return files_by_row
 
 

--- a/src/ingest_validation_tests/validator.py
+++ b/src/ingest_validation_tests/validator.py
@@ -136,21 +136,19 @@ class Validator:
         raise Exception("no uuid was found in the path to the current working directory")
 
 
-def get_non_global_paths_by_row(
-    rows: list[dict], base_path: Path, data_path_keys: bool = True
-) -> dict[str | int, str]:
+def get_non_global_paths_by_row(rows: list[dict], base_path: Path) -> dict[str | int, str]:
     """
     Create dict of non-global paths by row for a shared upload.
-    {<data_path_1 or 0>: [<path_1>, <path_2>], <data_path_2 or 1>: [<path_3>, <path_4>]}
+    {<data_path_1>: [<path_1>, <path_2>], <data_path_2>: [<path_3>, <path_4>]}
     """
     files_by_row = {}
-    for i, row in enumerate(rows):
+    for row in rows:
         non_global_files = row.get("non_global_files", "")
         # data_path is not a real path, but is necessary to distinguish files per dataset
         data_path = row["data_path"]
         if data_path in [".", "./"]:
             data_path = base_path
-        key = row if data_path_keys else i
+        key = data_path
         files_by_row[key] = [
             Path(f"non_global/{file.strip()}") for file in non_global_files.split(";")
         ]

--- a/src/ingest_validation_tests/validator.py
+++ b/src/ingest_validation_tests/validator.py
@@ -31,7 +31,7 @@ class Validator:
         assay_type: str,
         contains: list = [],
         verbose: bool = True,
-        schema=None,
+        schema_rows: list = [],
         globus_token: str = "",
         app_context: dict[str, str] = {},
         coreuse: int | None = None,
@@ -43,7 +43,7 @@ class Validator:
             assay_type: assay type string to be checked against self.required and self.contains
             contains: information from upstream SchemaVersion, only provided by multi-assay uploads
             verbose: controls printing in self._log
-            schema: SchemaVersion object from ingest-validation-tools
+            schema_rows: SchemaVersion.rows data from ingest-validation-tools
             globus_token: Globus auth token
             app_context: contains project and env-specific urls, headers
             coreuse: optionally pass in desired number of threads
@@ -63,18 +63,19 @@ class Validator:
         self.assay_type = assay_type
         self.contains = contains
         self.verbose = verbose
-        self.schema = schema
+        self.schema_rows = schema_rows
         self.token = globus_token
         self.app_context = app_context
         num_cpus = cpu_count()
         self.threads = coreuse if coreuse else num_cpus // 4 if (num_cpus and num_cpus >= 4) else 1
         self._log(f"Threading at {self.__class__.__name__} with {self.threads}")
 
-    def collect_errors(self) -> list[str | None]:
+    def collect_errors(self, **kwargs) -> list[str | None]:
         """
         Ensure plugin is valid, and if so, collect errors
         according to the subclass's _collect_errors method.
         """
+        # TODO: remove kwargs after plugin_kwargs logic is fixed upstream
         if not self.plugin_valid:
             return []
         self._log(f"Update: threading at {self.__class__.__name__} with {self.threads}")

--- a/src/ingest_validation_tests/validator.py
+++ b/src/ingest_validation_tests/validator.py
@@ -137,7 +137,7 @@ class Validator:
 
 
 def get_non_global_paths_by_row(
-    rows: list[dict], data_path_keys: bool = True
+    rows: list[dict], base_path: Path, data_path_keys: bool = True
 ) -> dict[str | int, str]:
     """
     Create dict of non-global paths by row for a shared upload.
@@ -147,7 +147,10 @@ def get_non_global_paths_by_row(
     for i, row in enumerate(rows):
         non_global_files = row.get("non_global_files", "")
         # data_path is not a real path, but is necessary to distinguish files per dataset
-        key = row["data_path"] if data_path_keys else i
+        data_path = row["data_path"]
+        if data_path in [".", "./"]:
+            data_path = base_path
+        key = row if data_path_keys else i
         files_by_row[key] = [
             Path(f"non_global/{file.strip()}") for file in non_global_files.split(";")
         ]

--- a/src/ingest_validation_tests/validator.py
+++ b/src/ingest_validation_tests/validator.py
@@ -64,6 +64,8 @@ class Validator:
         self.contains = contains
         self.verbose = verbose
         self.schema_rows = schema_rows
+        if not self.schema_rows and (schema := kwargs.get("schema")):
+            self.schema_rows = schema.rows
         self.token = globus_token
         self.app_context = app_context
         num_cpus = cpu_count()

--- a/src/ingest_validation_tests/validator.py
+++ b/src/ingest_validation_tests/validator.py
@@ -1,6 +1,7 @@
 import inspect
 import os
 import sys
+from csv import DictReader
 from importlib import util
 from os import cpu_count
 from pathlib import Path
@@ -132,6 +133,31 @@ class Validator:
             if len(elt) == 32 and all([c in "0123456789abcdef" for c in list(elt)]):
                 return elt
         raise Exception("no uuid was found in the path to the current working directory")
+
+
+def get_non_global_paths_by_row(
+    rows: list[dict], data_path_keys: bool = True
+) -> dict[str | int, str]:
+    """
+    Create dict of non-global paths by row for a shared upload.
+    {<data_path_1 or 0>: [<path_1>, <path_2>], <data_path_2 or 1>: [<path_3>, <path_4>]}
+    """
+    files_by_row = {}
+    for i, row in enumerate(rows):
+        non_global_files = row.get("non_global_files", "")
+        # data_path is not a real path, but is necessary to distinguish files per dataset
+        key = row["data_path"] if data_path_keys else i
+        files_by_row[key] = [
+            Path(f"non_global/{file.strip()}") for file in non_global_files.split(";")
+        ]
+    return files_by_row
+
+
+def read_tsv(path: Path, encoding: str = "utf-8") -> list[dict]:
+    with open(path, encoding=encoding) as f:
+        rows = list(DictReader(f, dialect="excel-tab"))
+        f.close()
+    return rows
 
 
 def check_ome_tiff_file(file: str | Path) -> xmlschema.XmlDocument:

--- a/tests/test_qptiff_channel_validator.py
+++ b/tests/test_qptiff_channel_validator.py
@@ -276,7 +276,7 @@ class TestQpTiffChannelCsv:
         )
         os.remove(Path(tmp_path / f"global/lab_processed/images/{self.test_csv_filename}"))
         validator.files_to_test
-        assert validator.errors == ["Unable to find csv for dataset row 0 in shared upload."]
+        assert validator.errors == ["Unable to find csv file for dataset row 0 in shared upload."]
 
     def test_shared_upload_bad_file_missing_in_tsv(self, tmp_path):
         """
@@ -293,7 +293,9 @@ class TestQpTiffChannelCsv:
             ],
         )
         validator.files_to_test
-        assert validator.errors == ["Unable to find qptiff for dataset row 0 in shared upload."]
+        assert validator.errors == [
+            "Unable to find qptiff file for dataset row 0 in shared upload."
+        ]
 
     def test_shared_upload_bad_extra_file_in_tsv(self, tmp_path):
         """
@@ -330,7 +332,7 @@ class TestQpTiffChannelCsv:
         )
         validator.files_to_test
         assert validator.errors == [
-            "Found 2 csvs (global/lab_processed/images/test.qptiff.channels.csv, global/lab_processed/images/2nd_test.qptiff.channels.csv) for dataset in row 0 in shared upload."
+            "Found 2 global csvs (global/lab_processed/images/test.qptiff.channels.csv, global/lab_processed/images/2nd_test.qptiff.channels.csv)."
         ]
 
     def test_shared_upload_mixed_outcome(self, monkeypatch, tmp_path):
@@ -353,7 +355,9 @@ class TestQpTiffChannelCsv:
             },
         )
         validator.files_to_test
-        assert validator.errors == ["Unable to find qptiff for dataset row 1 in shared upload."]
+        assert validator.errors == [
+            "Unable to find qptiff file for dataset row 1 in shared upload."
+        ]
         csv_path = Path(tmp_path / f"non_global/lab_processed/images/{self.test_csv_filename}")
         assert len(validator.files_to_test) == 1
         assert validator.files_to_test[0]["csv"] == csv_path

--- a/tests/test_qptiff_channel_validator.py
+++ b/tests/test_qptiff_channel_validator.py
@@ -1,7 +1,6 @@
 import csv
 import os
 import zipfile
-from dataclasses import dataclass
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -11,12 +10,6 @@ from qptiff_channel_validator import (  # type: ignore
     QpTiffChannelComparisonValidator,
     QpTiffChannelValidator,
 )
-
-
-@dataclass
-class MySchemaVersion:
-    def __init__(self, rows):
-        self.rows = rows
 
 
 class TestQpTiffChannelCsv:
@@ -199,7 +192,7 @@ class TestQpTiffChannelCsv:
         return QpTiffChannelValidator(
             [Path(tmp_path / "global"), Path(tmp_path / "non_global")],
             "phenocycler",
-            schema=MySchemaVersion(rows),
+            schema_rows=rows,
         )
 
     def _set_up_shared_upload_test(self, tmp_path, csv_in_global: bool, qptiff_in_global: bool):
@@ -292,18 +285,16 @@ class TestQpTiffChannelCsv:
         validator = QpTiffChannelValidator(
             [Path(tmp_path / "global"), Path(tmp_path / "non_global")],
             "phenocycler",
-            schema=MySchemaVersion(
-                [
-                    {
-                        "data_path": "./data_path_1",
-                        "non_global_files": f"./lab_processed/images/{self.test_csv_filename}",
-                    }
-                ]
-            ),
+            schema_rows=[
+                {
+                    "data_path": "./data_path_1",
+                    "non_global_files": f"./lab_processed/images/{self.test_csv_filename}",
+                }
+            ],
         )
         validator.files_to_test
         assert validator.errors == [
-            "Found 0 qptiffs and 1 channels.csv paths for dataset ./data_path_1 in shared upload."
+            "File(s) non_global/raw/images/test.qptiff found but missing from non_global_files column in metadata.tsv."
         ]
 
     def test_shared_upload_bad_extra_file_in_tsv(self, tmp_path):
@@ -314,14 +305,12 @@ class TestQpTiffChannelCsv:
         validator = QpTiffChannelValidator(
             [Path(tmp_path / "global"), Path(tmp_path / "non_global")],
             "phenocycler",
-            schema=MySchemaVersion(
-                [
-                    {
-                        "data_path": "./data_path_1",
-                        "non_global_files": f"./lab_processed/images/{self.test_csv_filename}",
-                    }
-                ]
-            ),
+            schema_rows=[
+                {
+                    "data_path": "./data_path_1",
+                    "non_global_files": f"./lab_processed/images/{self.test_csv_filename}",
+                }
+            ],
         )
         validator.files_to_test
         assert validator.errors == [
@@ -340,14 +329,12 @@ class TestQpTiffChannelCsv:
         validator = QpTiffChannelValidator(
             [Path(tmp_path / "global"), Path(tmp_path / "non_global")],
             "phenocycler",
-            schema=MySchemaVersion(
-                [
-                    {
-                        "data_path": "./data_path_1",
-                        "non_global_files": f"/something/else",
-                    }
-                ]
-            ),
+            schema_rows=[
+                {
+                    "data_path": "./data_path_1",
+                    "non_global_files": f"/something/else",
+                }
+            ],
         )
         validator.files_to_test
         assert validator.errors == [

--- a/tests/test_qptiff_channel_validator.py
+++ b/tests/test_qptiff_channel_validator.py
@@ -184,10 +184,10 @@ class TestQpTiffChannelCsv:
             mock_qptiff.write("good")
 
     def _create_shared_upload_validator(
-        self, tmp_path: Path, data_path_to_non_global: dict[str, str]
+        self, tmp_path: Path, data_row_to_non_global: dict[int, str]
     ) -> QpTiffChannelValidator:
         rows = []
-        for data_path, non_global_files in data_path_to_non_global.items():
+        for data_path, non_global_files in data_row_to_non_global.items():
             rows.append({"data_path": data_path, "non_global_files": non_global_files})
         return QpTiffChannelValidator(
             [Path(tmp_path / "global"), Path(tmp_path / "non_global")],
@@ -195,7 +195,9 @@ class TestQpTiffChannelCsv:
             schema_rows=rows,
         )
 
-    def _set_up_shared_upload_test(self, tmp_path, csv_in_global: bool, qptiff_in_global: bool):
+    def _set_up_shared_upload_test_dirs(
+        self, tmp_path: Path, csv_in_global: bool, qptiff_in_global: bool
+    ):
         self._create_shared_upload_dirs(tmp_path)
         csv_path = (
             "global/lab_processed/images" if csv_in_global else "non_global/lab_processed/images"
@@ -203,14 +205,15 @@ class TestQpTiffChannelCsv:
         qptiff_path = "global/raw/images" if qptiff_in_global else "non_global/raw/images"
         self._create_channels_csv_good(Path(tmp_path / csv_path))
         self._create_qptiff(Path(tmp_path / qptiff_path))
+
+    def _set_up_shared_upload_test(self, tmp_path, csv_in_global: bool, qptiff_in_global: bool):
+        self._set_up_shared_upload_test_dirs(tmp_path, csv_in_global, qptiff_in_global)
         non_global_files = []
         if not csv_in_global:
             non_global_files.append(f"./lab_processed/images/{self.test_csv_filename}")
         if not qptiff_in_global:
             non_global_files.append(f"./raw/images/{self.test_qptiff_filename}")
-        return self._create_shared_upload_validator(
-            tmp_path, {"./data_path_1": "; ".join(non_global_files)}
-        )
+        return self._create_shared_upload_validator(tmp_path, {0: "; ".join(non_global_files)})
 
     ######################
     # Test shared upload #
@@ -221,7 +224,7 @@ class TestQpTiffChannelCsv:
             tmp_path, csv_in_global=False, qptiff_in_global=False
         )
         assert validator.files_to_test == {
-            "./data_path_1": {
+            0: {
                 "csv": Path(
                     f"{tmp_path}/non_global/lab_processed/images/{self.test_csv_filename}"
                 ),
@@ -234,7 +237,7 @@ class TestQpTiffChannelCsv:
             tmp_path, csv_in_global=True, qptiff_in_global=False
         )
         assert validator.files_to_test == {
-            "./data_path_1": {
+            0: {
                 "csv": Path(f"{tmp_path}/global/lab_processed/images/{self.test_csv_filename}"),
                 "qptiff": Path(f"{tmp_path}/non_global/raw/images/{self.test_qptiff_filename}"),
             }
@@ -245,7 +248,7 @@ class TestQpTiffChannelCsv:
             tmp_path, csv_in_global=False, qptiff_in_global=True
         )
         assert validator.files_to_test == {
-            "./data_path_1": {
+            0: {
                 "csv": Path(
                     f"{tmp_path}/non_global/lab_processed/images/{self.test_csv_filename}"
                 ),
@@ -258,7 +261,7 @@ class TestQpTiffChannelCsv:
             tmp_path, csv_in_global=True, qptiff_in_global=True
         )
         assert validator.files_to_test == {
-            "./data_path_1": {
+            0: {
                 "csv": Path(f"{tmp_path}/global/lab_processed/images/{self.test_csv_filename}"),
                 "qptiff": Path(f"{tmp_path}/global/raw/images/{self.test_qptiff_filename}"),
             }
@@ -273,9 +276,7 @@ class TestQpTiffChannelCsv:
         )
         os.remove(Path(tmp_path / f"global/lab_processed/images/{self.test_csv_filename}"))
         validator.files_to_test
-        assert validator.errors == [
-            "Found 1 qptiff(s) (global/raw/images/test.qptiff) and 0 channels.csv(s) for dataset ./data_path_1 in shared upload."
-        ]
+        assert validator.errors == ["Unable to find csv for dataset row 0 in shared upload."]
 
     def test_shared_upload_bad_file_missing_in_tsv(self, tmp_path):
         """
@@ -287,15 +288,12 @@ class TestQpTiffChannelCsv:
             "phenocycler",
             schema_rows=[
                 {
-                    "data_path": "./data_path_1",
                     "non_global_files": f"./lab_processed/images/{self.test_csv_filename}",
                 }
             ],
         )
         validator.files_to_test
-        assert validator.errors == [
-            "Found 0 qptiff(s) and 1 channels.csv(s) (non_global/lab_processed/images/test.qptiff.channels.csv) for dataset ./data_path_1 in shared upload.",
-        ]
+        assert validator.errors == ["Unable to find qptiff for dataset row 0 in shared upload."]
 
     def test_shared_upload_bad_extra_file_in_tsv(self, tmp_path):
         """
@@ -307,14 +305,13 @@ class TestQpTiffChannelCsv:
             "phenocycler",
             schema_rows=[
                 {
-                    "data_path": "./data_path_1",
                     "non_global_files": f"./lab_processed/images/{self.test_csv_filename}",
                 }
             ],
         )
         validator.files_to_test
         assert validator.errors == [
-            "Path non_global/lab_processed/images/test.qptiff.channels.csv doesn't exist."
+            "Files listed in non_global_files field do not exist: test_shared_upload_bad_extra_f0/non_global/lab_processed/images/test.qptiff.channels.csv"
         ]
 
     def test_shared_upload_bad_multiple_global(self, tmp_path):
@@ -329,17 +326,39 @@ class TestQpTiffChannelCsv:
         validator = QpTiffChannelValidator(
             [Path(tmp_path / "global"), Path(tmp_path / "non_global")],
             "phenocycler",
-            schema_rows=[
-                {
-                    "data_path": "./data_path_1",
-                    "non_global_files": f"/something/else",
-                }
-            ],
+            schema_rows=[{}],
         )
         validator.files_to_test
         assert validator.errors == [
-            "Found 1 qptiff(s) (global/raw/images/test.qptiff) and 2 channels.csv(s) (global/lab_processed/images/test.qptiff.channels.csv, global/lab_processed/images/2nd_test.qptiff.channels.csv) for dataset ./data_path_1 in shared upload.",
+            "Found 2 csvs (global/lab_processed/images/test.qptiff.channels.csv, global/lab_processed/images/2nd_test.qptiff.channels.csv) for dataset in row 0 in shared upload."
         ]
+
+    def test_shared_upload_mixed_outcome(self, monkeypatch, tmp_path):
+        """
+        One file pair is fine, the other is missing a file.
+        Make sure the good pair is validated and the error is logged for the bad pair.
+        """
+        self._set_up_shared_upload_test_dirs(tmp_path, csv_in_global=False, qptiff_in_global=False)
+        self._create_channels_csv_good(
+            Path(tmp_path / "non_global/lab_processed/images/"),
+            filename=f"2nd_{self.test_csv_filename}",
+        )
+        mock = Mock()
+        monkeypatch.setattr(QpTiffChannelValidator, "check_qptiff_channels_file", mock)
+        validator = self._create_shared_upload_validator(
+            tmp_path,
+            {
+                0: f"raw/images/{self.test_qptiff_filename}; lab_processed/images/{self.test_csv_filename}",
+                1: f"lab_processed/images/2nd_{self.test_csv_filename}",
+            },
+        )
+        validator.files_to_test
+        assert validator.errors == ["Unable to find qptiff for dataset row 1 in shared upload."]
+        csv_path = Path(tmp_path / f"non_global/lab_processed/images/{self.test_csv_filename}")
+        assert len(validator.files_to_test) == 1
+        assert validator.files_to_test[0]["csv"] == csv_path
+        validator.collect_errors()
+        mock.assert_called_with(csv_path)
 
 
 class TestQptiffChannelComparisonValidator:

--- a/tests/test_qptiff_channel_validator.py
+++ b/tests/test_qptiff_channel_validator.py
@@ -1,13 +1,22 @@
+import csv
+import os
 import zipfile
+from dataclasses import dataclass
 from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
-from qptiff_channel_validator import (
+from qptiff_channel_validator import (  # type: ignore
     Engine,
     QpTiffChannelComparisonValidator,
     QpTiffChannelValidator,
 )
+
+
+@dataclass
+class MySchemaVersion:
+    def __init__(self, rows):
+        self.rows = rows
 
 
 class TestQpTiffChannelCsv:
@@ -88,14 +97,8 @@ class TestQpTiffChannelCsv:
             assert err in errors
 
     def test_missing_channels_csv(self, tmp_path):
-        lab_dir = tmp_path / "lab_processed"
-        lab_dir.mkdir()
-        lab_images_dir = lab_dir / "images"
-        lab_images_dir.mkdir()
-        raw_dir = tmp_path / "raw"
-        raw_dir.mkdir()
-        raw_images_dir = raw_dir / "images"
-        raw_images_dir.mkdir()
+        Path(tmp_path / "lab_processed/images").mkdir(parents=True)
+        Path(tmp_path / "raw/images").mkdir(parents=True)
         validator = QpTiffChannelValidator(tmp_path, "phenocycler")
         errors = validator.collect_errors()[:]
         errors.sort()
@@ -154,13 +157,210 @@ class TestQpTiffChannelCsv:
         for error in msg_re_list:
             assert error in validator.errors
 
+    #######################
+    # Setup shared upload #
+    #######################
+
+    test_csv_filename = "test.qptiff.channels.csv"
+    test_qptiff_filename = "test.qptiff"
+
+    def _create_shared_upload_dirs(self, tmp_dir):
+        Path(tmp_dir / "global/lab_processed/images").mkdir(parents=True)
+        Path(tmp_dir / "global/raw/images").mkdir(parents=True)
+        Path(tmp_dir / "non_global/lab_processed/images").mkdir(parents=True)
+        Path(tmp_dir / "non_global/raw/images").mkdir(parents=True)
+
+    def _create_channels_csv_good(self, output_dir: Path, filename: str | None = None):
+        if not filename:
+            filename = self.test_csv_filename
+        with open(Path(output_dir / filename), "w", newline="") as mock_csv:
+            writer = csv.writer(mock_csv)
+            writer.writerows(
+                [
+                    {
+                        "channel_id": "Channel:0:0",
+                        "is_channel_used_for_nuclei_segmentation": "Yes",
+                        "is_channel_used_for_cell_segmentation": "No",
+                        "is_antibody": "No",
+                    }
+                ]
+            )
+
+    def _create_qptiff(self, output_dir: Path):
+        with open(Path(output_dir / self.test_qptiff_filename), "w", newline="") as mock_qptiff:
+            mock_qptiff.write("good")
+
+    def _create_shared_upload_validator(
+        self, tmp_path: Path, data_path_to_non_global: dict[str, str]
+    ) -> QpTiffChannelValidator:
+        rows = []
+        for data_path, non_global_files in data_path_to_non_global.items():
+            rows.append({"data_path": data_path, "non_global_files": non_global_files})
+        return QpTiffChannelValidator(
+            [Path(tmp_path / "global"), Path(tmp_path / "non_global")],
+            "phenocycler",
+            schema=MySchemaVersion(rows),
+        )
+
+    def _set_up_shared_upload_test(self, tmp_path, csv_in_global: bool, qptiff_in_global: bool):
+        self._create_shared_upload_dirs(tmp_path)
+        csv_path = (
+            "global/lab_processed/images" if csv_in_global else "non_global/lab_processed/images"
+        )
+        qptiff_path = "global/raw/images" if qptiff_in_global else "non_global/raw/images"
+        self._create_channels_csv_good(Path(tmp_path / csv_path))
+        self._create_qptiff(Path(tmp_path / qptiff_path))
+        non_global_files = []
+        if not csv_in_global:
+            non_global_files.append(f"./lab_processed/images/{self.test_csv_filename}")
+        if not qptiff_in_global:
+            non_global_files.append(f"./raw/images/{self.test_qptiff_filename}")
+        return self._create_shared_upload_validator(
+            tmp_path, {"./data_path_1": "; ".join(non_global_files)}
+        )
+
+    ######################
+    # Test shared upload #
+    ######################
+
+    def test_shared_upload_good_all_in_non_global(self, tmp_path):
+        validator = self._set_up_shared_upload_test(
+            tmp_path, csv_in_global=False, qptiff_in_global=False
+        )
+        assert validator.files_to_test == {
+            "./data_path_1": {
+                "csv": Path(
+                    f"{tmp_path}/non_global/lab_processed/images/{self.test_csv_filename}"
+                ),
+                "qptiff": Path(f"{tmp_path}/non_global/raw/images/{self.test_qptiff_filename}"),
+            }
+        }
+
+    def test_shared_upload_good_mixed1(self, tmp_path):
+        validator = self._set_up_shared_upload_test(
+            tmp_path, csv_in_global=True, qptiff_in_global=False
+        )
+        assert validator.files_to_test == {
+            "./data_path_1": {
+                "csv": Path(f"{tmp_path}/global/lab_processed/images/{self.test_csv_filename}"),
+                "qptiff": Path(f"{tmp_path}/non_global/raw/images/{self.test_qptiff_filename}"),
+            }
+        }
+
+    def test_shared_upload_good_mixed_2(self, tmp_path):
+        validator = self._set_up_shared_upload_test(
+            tmp_path, csv_in_global=False, qptiff_in_global=True
+        )
+        assert validator.files_to_test == {
+            "./data_path_1": {
+                "csv": Path(
+                    f"{tmp_path}/non_global/lab_processed/images/{self.test_csv_filename}"
+                ),
+                "qptiff": Path(f"{tmp_path}/global/raw/images/{self.test_qptiff_filename}"),
+            }
+        }
+
+    def test_shared_upload_good_all_in_global(self, tmp_path):
+        validator = self._set_up_shared_upload_test(
+            tmp_path, csv_in_global=True, qptiff_in_global=True
+        )
+        assert validator.files_to_test == {
+            "./data_path_1": {
+                "csv": Path(f"{tmp_path}/global/lab_processed/images/{self.test_csv_filename}"),
+                "qptiff": Path(f"{tmp_path}/global/raw/images/{self.test_qptiff_filename}"),
+            }
+        }
+
+    def test_shared_upload_bad_missing_file(self, tmp_path):
+        """
+        Detect missing file between non_global and global dirs
+        """
+        validator = self._set_up_shared_upload_test(
+            tmp_path, csv_in_global=True, qptiff_in_global=True
+        )
+        os.remove(Path(tmp_path / f"global/lab_processed/images/{self.test_csv_filename}"))
+        validator.files_to_test
+        assert validator.errors == [
+            "Found 1 qptiffs and 0 channels.csv paths for dataset ./data_path_1 in shared upload."
+        ]
+
+    def test_shared_upload_bad_file_missing_in_tsv(self, tmp_path):
+        """
+        File in non_global missing from metadata.tsv > non_global_files
+        """
+        self._set_up_shared_upload_test(tmp_path, csv_in_global=False, qptiff_in_global=False)
+        validator = QpTiffChannelValidator(
+            [Path(tmp_path / "global"), Path(tmp_path / "non_global")],
+            "phenocycler",
+            schema=MySchemaVersion(
+                [
+                    {
+                        "data_path": "./data_path_1",
+                        "non_global_files": f"./lab_processed/images/{self.test_csv_filename}",
+                    }
+                ]
+            ),
+        )
+        validator.files_to_test
+        assert validator.errors == [
+            "Found 0 qptiffs and 1 channels.csv paths for dataset ./data_path_1 in shared upload."
+        ]
+
+    def test_shared_upload_bad_extra_file_in_tsv(self, tmp_path):
+        """
+        File in metadata.tsv > non_global_files is actually in global
+        """
+        self._set_up_shared_upload_test(tmp_path, csv_in_global=True, qptiff_in_global=True)
+        validator = QpTiffChannelValidator(
+            [Path(tmp_path / "global"), Path(tmp_path / "non_global")],
+            "phenocycler",
+            schema=MySchemaVersion(
+                [
+                    {
+                        "data_path": "./data_path_1",
+                        "non_global_files": f"./lab_processed/images/{self.test_csv_filename}",
+                    }
+                ]
+            ),
+        )
+        validator.files_to_test
+        assert validator.errors == [
+            "Path non_global/lab_processed/images/test.qptiff.channels.csv doesn't exist."
+        ]
+
+    def test_shared_upload_bad_multiple_global(self, tmp_path):
+        """
+        Multiple channels.csv files found in global
+        """
+        self._set_up_shared_upload_test(tmp_path, csv_in_global=True, qptiff_in_global=True)
+        self._create_channels_csv_good(
+            Path(tmp_path / "global/lab_processed/images/"),
+            filename=f"2nd_{self.test_csv_filename}",
+        )
+        validator = QpTiffChannelValidator(
+            [Path(tmp_path / "global"), Path(tmp_path / "non_global")],
+            "phenocycler",
+            schema=MySchemaVersion(
+                [
+                    {
+                        "data_path": "./data_path_1",
+                        "non_global_files": f"/something/else",
+                    }
+                ]
+            ),
+        )
+        validator.files_to_test
+        assert validator.errors == [
+            "Found 1 qptiffs and 2 channels.csv paths for dataset ./data_path_1 in shared upload."
+        ]
+
 
 class TestQptiffChannelComparisonValidator:
     @pytest.fixture(autouse=True)
     def _mock_validator_good(self, monkeypatch):
         monkeypatch.setattr(QpTiffChannelComparisonValidator, "uuid", "test_uuid")
 
-    def test_check_tmp_dir(self, monkeypatch, _mock_validator_good, tmp_path):
+    def test_check_tmp_dir(self, monkeypatch, tmp_path):
         v = QpTiffChannelComparisonValidator(tmp_path, "phenocycler")
         monkeypatch.setattr(QpTiffChannelComparisonValidator, "tmp_dir_base", tmp_path)
         tmp_dir = Path(v.tmp_dir_base / "test_uuid_ome_xml")

--- a/tests/test_qptiff_channel_validator.py
+++ b/tests/test_qptiff_channel_validator.py
@@ -274,7 +274,7 @@ class TestQpTiffChannelCsv:
         os.remove(Path(tmp_path / f"global/lab_processed/images/{self.test_csv_filename}"))
         validator.files_to_test
         assert validator.errors == [
-            "Found 1 qptiffs and 0 channels.csv paths for dataset ./data_path_1 in shared upload."
+            "Found 1 qptiff(s) (global/raw/images/test.qptiff) and 0 channels.csv(s) for dataset ./data_path_1 in shared upload."
         ]
 
     def test_shared_upload_bad_file_missing_in_tsv(self, tmp_path):
@@ -294,7 +294,7 @@ class TestQpTiffChannelCsv:
         )
         validator.files_to_test
         assert validator.errors == [
-            "File(s) non_global/raw/images/test.qptiff found but missing from non_global_files column in metadata.tsv."
+            "Found 0 qptiff(s) and 1 channels.csv(s) (non_global/lab_processed/images/test.qptiff.channels.csv) for dataset ./data_path_1 in shared upload.",
         ]
 
     def test_shared_upload_bad_extra_file_in_tsv(self, tmp_path):
@@ -338,7 +338,7 @@ class TestQpTiffChannelCsv:
         )
         validator.files_to_test
         assert validator.errors == [
-            "Found 1 qptiffs and 2 channels.csv paths for dataset ./data_path_1 in shared upload."
+            "Found 1 qptiff(s) (global/raw/images/test.qptiff) and 2 channels.csv(s) (global/lab_processed/images/test.qptiff.channels.csv, global/lab_processed/images/2nd_test.qptiff.channels.csv) for dataset ./data_path_1 in shared upload.",
         ]
 
 

--- a/tests/test_segmentation_mask_imagesize_validator.py
+++ b/tests/test_segmentation_mask_imagesize_validator.py
@@ -1,17 +1,10 @@
 import re
 import zipfile
-from dataclasses import dataclass
 from pathlib import Path
 from unittest.mock import patch
 
 import pandas as pd  # to parse metadata.tsv
 import pytest
-
-
-@dataclass
-class MySchemaVersion:
-    def __init__(self, rows):
-        self.rows = rows
 
 
 @pytest.mark.parametrize(
@@ -64,9 +57,11 @@ def test_segmentation_mask_imagesize_validator(
     tsv_path_l = list((tmp_seg_path / test_data_path.stem).glob("*metadata.tsv"))
     assert len(tsv_path_l) == 1, "Failed to find one metadata file"
     recs_df = pd.read_csv(tsv_path_l[0], sep="\t")
-    sv = MySchemaVersion(rows=recs_df.to_dict("records"))
     validator = ImageSizeValidator(
-        tmp_seg_path / test_data_path.stem, assay_type, schema=sv, coreuse=4
+        tmp_seg_path / test_data_path.stem,
+        assay_type,
+        schema_rows=recs_df.to_dict("records"),
+        coreuse=4,
     )
     errors = validator.collect_errors()[:]
     assert len(msg_re_list) == len(errors)


### PR DESCRIPTION
Find files in shared uploads appropriately during QPTIFF channel validation.

## Note
- Requires update to `ingest-validation-tools` (which in turn prompts a non-urgent update to `ingest-pipeline`) because shared uploads do not currently provide SchemaVersion.
     - https://github.com/hubmapconsortium/ingest-validation-tools/pull/1509
     - https://github.com/hubmapconsortium/ingest-pipeline/pull/1278

## Other changes
- Replaces `Validator.schema: SchemaVersion` param with `Validator.schema_rows: list[dict]` to simplify data passed in to validator (see note above).
- Rolls back `tifffile` version to match the version in `ingest-pipeline`.
- Tests.

-----
# Extra context

## Background
- QPTIFF channel comparison requires a pair of files: a `.channels.csv` and a `.qptiff`.
- These may be in `global` (and?/)or `non_global` in a shared upload.
- Previous logic failed if the files were missing from one of these directories. This fixes that problem.

## Details
- Implements a path in `QpTiffChannelValidator.files_to_test` that handles shared uploads.
- The file-finder consults the `non_global_files` field of the `metadata.tsv` to make an inventory of `data_path`s : list of non-global files for that dataset.
- The file finder looks for a `.channels.csv` file and a `.qptiff` file in `non_global` for each dataset. If found in the `non_global_files` field, check that files actually exist.
    - Happy path 1: finds both files in `non_global`.
- If one or more of the pair is missing, the file finder looks in `global`.
    - Happy path 2: one or more of the required files are found in `global`.
- Sad path: one or more of the files in a pair are missing after the file finder has checked in both the `non_global_files` output and the actual `global` directory. Possible causes: file in `non_global` that's not listed in `non_global_files`, file missing entirely. Log error for that `data_path` including any found filenames and do not include in `files_to_test`.
