### PR TITLE
Bugfixes: ensure OME-XML schema, handle int data_path values

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ pandas==2.2.3
 python-frontmatter>=1.1.0
 requests==2.32.3
 tifffile==2024.6.18
-xmlschema==3.4.5
+xmlschema==4.1.0

--- a/src/ingest_validation_tests/ome_tiff_schemas/2016-06_ome.xsd
+++ b/src/ingest_validation_tests/ome_tiff_schemas/2016-06_ome.xsd
@@ -1,0 +1,4898 @@
+<?xml version = "1.0" encoding = "UTF-8"?>
+<!--
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
+# Copyright (C) 2002 - 2016 Open Microscopy Environment
+#       Massachusetts Institute of Technology,
+#       National Institutes of Health,
+#       University of Dundee,
+#       University of Wisconsin at Madison
+#
+# This work is licensed under the
+#       Creative Commons Attribution 3.0 Unported License.
+# To view a copy of this license, visit
+#       http://creativecommons.org/licenses/by/3.0/
+# or send a letter to
+#       Creative Commons, 444 Castro Street, Suite 900,
+#       Mountain View, California, 94041, USA.
+# For attribution instructions, visit
+#       http://www.openmicroscopy.org/info/attribution
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-->
+<xsd:schema xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06"
+            targetNamespace="http://www.openmicroscopy.org/Schemas/OME/2016-06"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:OME="http://www.openmicroscopy.org/Schemas/OME/2016-06"
+            xmlns:xml="http://www.w3.org/XML/1998/namespace"
+            version="2"
+            elementFormDefault="qualified">
+
+  <xsd:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+
+  <xsd:annotation>
+    <xsd:documentation>
+      Open Microscopy Environment
+      OME XML Schema June 2016
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <!-- Main OME element -->
+  <xsd:element name="OME"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:documentation>
+        The OME element is a container for all information objects accessible by OME.
+        These information objects include descriptions of the imaging experiments
+        and the people who perform them, descriptions of the microscope, the resulting
+        images and how they were acquired, the analyses performed on those images,
+        and the analysis results themselves.
+        An OME file may contain any or all of this information.
+
+        With the creation of the Metadata Only Companion OME-XML and Binary Only OME-TIFF files
+        the top level OME node has changed slightly.
+        It can EITHER:
+        Contain all the previously expected elements
+        OR:
+        Contain a single BinaryOnly element that points at
+        its Metadata Only Companion OME-XML file.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="Rights" minOccurs="0" maxOccurs="1"/>
+        <xsd:choice>
+          <!-- Either: standard expected elements -->
+          <xsd:sequence>
+            <xsd:element ref="Project" minOccurs="0" maxOccurs="unbounded"/>
+            <xsd:element ref="Dataset" minOccurs="0" maxOccurs="unbounded"/>
+            <xsd:element ref="Folder" minOccurs="0" maxOccurs="unbounded"/>
+            <xsd:element ref="Experiment" minOccurs="0" maxOccurs="unbounded"/>
+            <xsd:element ref="Plate" minOccurs="0" maxOccurs="unbounded"/>
+            <xsd:element ref="Screen" minOccurs="0" maxOccurs="unbounded"/>
+            <xsd:element ref="Experimenter" minOccurs="0" maxOccurs="unbounded"/>
+            <xsd:element ref="ExperimenterGroup" minOccurs="0" maxOccurs="unbounded"/>
+            <xsd:element ref="Instrument" minOccurs="0" maxOccurs="unbounded"/>
+            <xsd:element ref="Image" minOccurs="0" maxOccurs="unbounded"/>
+            <xsd:element ref="StructuredAnnotations" minOccurs="0" maxOccurs="1"/>
+            <xsd:element ref="ROI" minOccurs="0" maxOccurs="unbounded"/>
+          </xsd:sequence>
+          <!-- Or: Single BinaryOnly element -->
+          <xsd:element name="BinaryOnly" minOccurs="1" maxOccurs="1">
+            <xsd:annotation>
+              <xsd:documentation> Pointer to an external metadata file. If this
+              element is present, then no other metadata may be present in this
+              file, i.e. this file is a place-holder. </xsd:documentation>
+            </xsd:annotation>
+            <xsd:complexType>
+              <xsd:attribute name="MetadataFile" type="xsd:string" use="required">
+                <xsd:annotation>
+                  <xsd:documentation> Filename of the OME-XML metadata file for
+                  this binary data. If the file cannot be found, a search can
+                  be performed based on the UUID. </xsd:documentation>
+                </xsd:annotation>
+              </xsd:attribute>
+              <xsd:attribute name="UUID" type="UniversallyUniqueIdentifier"
+                             use="required">
+                <xsd:annotation>
+                  <xsd:documentation> The unique identifier of another OME-XML
+                  block whose metadata describes the binary data in this file.
+                  This UUID is considered authoritative regardless of
+                  mismatches in the filename. </xsd:documentation>
+                </xsd:annotation>
+              </xsd:attribute>
+            </xsd:complexType>
+          </xsd:element>
+          <!-- End of MetadataOnly Element -->
+        </xsd:choice>
+      </xsd:sequence>
+      <xsd:attribute name="UUID" type="UniversallyUniqueIdentifier" use="optional">
+        <xsd:annotation>
+          <xsd:documentation>
+            This unique identifier is used to keep track of multi part files.
+            It allows the links between files to survive renaming.
+
+            While OPTIONAL in the general case this is REQUIRED in a
+            MetadataOnly Companion to a collection of BinaryOnly files.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="Creator" type="xsd:string" use="optional">
+        <xsd:annotation>
+          <xsd:documentation>
+            This is the name of the creating application of the OME-XML
+            and preferably its full version.
+            e.g "CompanyName, SoftwareName, V2.6.3456"
+            This is optional but we hope it will be set by applications
+            writing out OME-XML from scratch.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+
+    <!-- Unique IDs -->
+    <xsd:key name="ChannelIDKey"><xsd:selector xpath="OME:Image/OME:Pixels/OME:Channel"/><xsd:field xpath="@ID"/></xsd:key>
+    <xsd:key name="DatasetIDKey"><xsd:selector xpath="OME:Dataset"/><xsd:field xpath="@ID"/></xsd:key>
+    <xsd:key name="DetectorIDKey"><xsd:selector xpath="OME:Instrument/OME:Detector"/><xsd:field xpath="@ID"/></xsd:key>
+    <xsd:key name="DichroicIDKey"><xsd:selector xpath="OME:Instrument/OME:Dichroic"/><xsd:field xpath="@ID"/></xsd:key>
+    <xsd:key name="ExperimentIDKey"><xsd:selector xpath="OME:Experiment"/><xsd:field xpath="@ID"/></xsd:key>
+    <xsd:key name="ExperimenterIDKey"><xsd:selector xpath="OME:Experimenter"/><xsd:field xpath="@ID"/></xsd:key>
+    <xsd:key name="FilterIDKey"><xsd:selector xpath="OME:Instrument/OME:Filter"/><xsd:field xpath="@ID"/></xsd:key>
+    <xsd:key name="FilterSetIDKey"><xsd:selector xpath="OME:Instrument/OME:FilterSet"/><xsd:field xpath="@ID"/></xsd:key>
+    <xsd:key name="FolderIDKey"><xsd:selector xpath="OME:Folder"/><xsd:field xpath="@ID"/></xsd:key>
+    <xsd:key name="ExperimenterGroupIDKey"><xsd:selector xpath="OME:ExperimenterGroup"/><xsd:field xpath="@ID"/></xsd:key>
+    <xsd:key name="ImageIDKey"><xsd:selector xpath="OME:Image"/><xsd:field xpath="@ID"/></xsd:key>
+    <xsd:key name="InstrumentIDKey"><xsd:selector xpath="OME:Instrument"/><xsd:field xpath="@ID"/></xsd:key>
+    <xsd:key name="LightSourceIDKey"><xsd:selector xpath="OME:Instrument/OME:Laser|OME:Instrument/OME:Arc|OME:Instrument/OME:Filament|OME:Instrument/OME:LightEmittingDiode|OME:Instrument/OME:GenericExcitationSource"/><xsd:field xpath="@ID"/></xsd:key>
+    <xsd:key name="MicrobeamManipulationIDKey"><xsd:selector xpath="OME:Experiment/OME:MicrobeamManipulation"/><xsd:field xpath="@ID"/></xsd:key>
+    <xsd:key name="ObjectiveIDKey"><xsd:selector xpath="OME:Instrument/OME:Objective"/><xsd:field xpath="@ID"/></xsd:key>
+    <xsd:key name="PixelsIDKey"><xsd:selector xpath="OME:Image/OME:Pixels"/><xsd:field xpath="@ID"/></xsd:key>
+    <xsd:key name="PlateIDKey"><xsd:selector xpath="OME:Plate"/><xsd:field xpath="@ID"/></xsd:key>
+    <xsd:key name="ProjectIDKey"><xsd:selector xpath="OME:Project"/><xsd:field xpath="@ID"/></xsd:key>
+    <xsd:key name="ReagentIDKey"><xsd:selector xpath="OME:Screen/OME:Reagent"/><xsd:field xpath="@ID"/></xsd:key>
+    <xsd:key name="ScreenAcquisitionIDKey"><xsd:selector xpath="OME:Screen/OME:ScreenAcquisition"/><xsd:field xpath="@ID"/></xsd:key>
+    <xsd:key name="ScreenIDKey"><xsd:selector xpath="OME:Screen"/><xsd:field xpath="@ID"/></xsd:key>
+    <xsd:key name="WellIDKey"><xsd:selector xpath="OME:Plate/OME:Well"/><xsd:field xpath="@ID"/></xsd:key>
+    <xsd:key name="WellSampleIDKey"><xsd:selector xpath="OME:Plate/OME:Well/OME:WellSample"/><xsd:field xpath="@ID"/></xsd:key>
+    <xsd:key name="ROIIDKey"><xsd:selector xpath="OME:ROI"/><xsd:field xpath="@ID"/></xsd:key>
+    <xsd:key name="ShapeIDKey"><xsd:selector xpath="OME:ROI/OME:Union/OME:Rectangle|OME:ROI/OME:Union/OME:Mask|OME:ROI/OME:Union/OME:Ellipse|OME:ROI/OME:Union/OME:Point|OME:ROI/OME:Union/OME:Line|OME:ROI/OME:Union/OME:Polyline|OME:ROI/OME:Union/OME:Polygon|OME:ROI/OME:Union/OME:Label"/><xsd:field xpath="@ID"/></xsd:key>
+    <xsd:key name="AnnotationIDKey"><xsd:selector xpath="OME:StructuredAnnotations/*"/><xsd:field xpath="@ID"/></xsd:key>
+
+    <!-- Unique references -->
+    <xsd:key name="WellSampleImageRefIDKey"><xsd:selector xpath="OME:Plate/OME:Well/OME:WellSample/OME:ImageRef"/><xsd:field xpath="@ID"/></xsd:key>
+
+    <!-- Valid references -->
+    <xsd:keyref name="DatasetExperimenterIDKeyRef" refer="OME:ExperimenterIDKey" ><xsd:selector xpath="OME:Dataset/OME:ExperimenterRef"/><xsd:field xpath="@ID"/></xsd:keyref>
+    <xsd:keyref name="DatasetExperimenterGroupIDKeyRef" refer="OME:ExperimenterGroupIDKey" ><xsd:selector xpath="OME:Dataset/OME:ExperimenterGroupRef"/><xsd:field xpath="@ID"/></xsd:keyref>
+    <xsd:keyref name="DatasetProjectIDKeyRef" refer="OME:ProjectIDKey" ><xsd:selector xpath="OME:Dataset/OME:ProjectRef"/><xsd:field xpath="@ID"/></xsd:keyref>
+    <xsd:keyref name="ExperimentExperimenterIDKeyRef" refer="OME:ExperimenterIDKey" ><xsd:selector xpath="OME:Experiment/OME:ExperimenterRef"/><xsd:field xpath="@ID"/></xsd:keyref>
+    <xsd:keyref name="ExperimentMicrobeamManipulationExperimenterIDKeyRef" refer="OME:ExperimenterIDKey" ><xsd:selector xpath="OME:Experiment/OME:MicrobeamManipulation/OME:ExperimenterRef"/><xsd:field xpath="@ID"/></xsd:keyref>
+    <xsd:keyref name="ExperimentMicrobeamManipulationLightSourceSettingsLightSourceIDKeyRef" refer="OME:LightSourceIDKey" ><xsd:selector xpath="OME:Experiment/OME:MicrobeamManipulation/OME:LightSourceSettings"/><xsd:field xpath="@ID"/></xsd:keyref>
+    <xsd:keyref name="ExperimenterExperimenterGroupIDKeyRef" refer="OME:ExperimenterGroupIDKey" ><xsd:selector xpath="OME:Experimenter/OME:ExperimenterGroupRef"/><xsd:field xpath="@ID"/></xsd:keyref>
+    <xsd:keyref name="ExperimenterGroupContactExperimenterIDKeyRef" refer="OME:ExperimenterIDKey" ><xsd:selector xpath="OME:ExperimenterGroup/OME:Contact"/><xsd:field xpath="@ID"/></xsd:keyref>
+    <xsd:keyref name="ExperimenterGroupLeaderExperimenterIDKeyRef" refer="OME:ExperimenterIDKey" ><xsd:selector xpath="OME:ExperimenterGroup/OME:Leader"/><xsd:field xpath="@ID"/></xsd:keyref>
+    <xsd:keyref name="FolderFolderIDKeyRef" refer="OME:FolderIDKey" ><xsd:selector xpath="OME:Folder/OME:FolderRef"/><xsd:field xpath="@ID"/></xsd:keyref>
+    <xsd:keyref name="FolderImageIDKeyRef" refer="OME:ImageIDKey" ><xsd:selector xpath="OME:Folder/OME:ImageRef"/><xsd:field xpath="@ID"/></xsd:keyref>
+    <xsd:keyref name="FolderROIIDKeyRef" refer="OME:ROIIDKey" ><xsd:selector xpath="OME:Folder/OME:ROIRef"/><xsd:field xpath="@ID"/></xsd:keyref>
+    <xsd:keyref name="ImageDatasetIDKeyRef" refer="OME:DatasetIDKey" ><xsd:selector xpath="OME:Image/OME:DatasetRef"/><xsd:field xpath="@ID"/></xsd:keyref>
+    <xsd:keyref name="ImageExperimenterIDKeyRef" refer="OME:ExperimenterIDKey" ><xsd:selector xpath="OME:Image/OME:ExperimenterRef"/><xsd:field xpath="@ID"/></xsd:keyref>
+    <xsd:keyref name="ImageExperimentIDKeyRef" refer="OME:ExperimentIDKey" ><xsd:selector xpath="OME:Image/OME:ExperimentRef"/><xsd:field xpath="@ID"/></xsd:keyref>
+    <xsd:keyref name="ImageExperimenterGroupIDKeyRef" refer="OME:ExperimenterGroupIDKey" ><xsd:selector xpath="OME:Image/OME:ExperimenterGroupRef"/><xsd:field xpath="@ID"/></xsd:keyref>
+    <xsd:keyref name="ImageInstrumentIDKeyRef" refer="OME:InstrumentIDKey" ><xsd:selector xpath="OME:Image/OME:InstrumentRef"/><xsd:field xpath="@ID"/></xsd:keyref>
+    <xsd:keyref name="ImageMicrobeamManipulationIDKeyRef" refer="OME:MicrobeamManipulationIDKey" ><xsd:selector xpath="OME:Image/OME:MicrobeamManipulationRef"/><xsd:field xpath="@ID"/></xsd:keyref>
+    <xsd:keyref name="ImageObjectiveSettingsObjectiveIDKeyRef" refer="OME:ObjectiveIDKey" ><xsd:selector xpath="OME:Image/OME:ObjectiveSettings"/><xsd:field xpath="@ID"/></xsd:keyref>
+    <xsd:keyref name="ImagePixelsChannelDetectorSettingsDetectorIDKeyRef" refer="OME:DetectorIDKey" ><xsd:selector xpath="OME:Image/OME:Pixels/OME:Channel/OME:DetectorSettings"/><xsd:field xpath="@ID"/></xsd:keyref>
+    <xsd:keyref name="ImagePixelsChannelFilterSetIDKeyRef" refer="OME:FilterSetIDKey" ><xsd:selector xpath="OME:Image/OME:Pixels/OME:Channel/OME:FilterSetRef"/><xsd:field xpath="@ID"/></xsd:keyref>
+    <xsd:keyref name="ImagePixelsChannelLightPathExcitationFilterIDKeyRef" refer="OME:FilterIDKey" ><xsd:selector xpath="OME:Image/OME:Pixels/OME:Channel/OME:LightPath/OME:ExcitationFilterPath/OME:FilterRef"/><xsd:field xpath="@ID"/></xsd:keyref>
+    <xsd:keyref name="ImagePixelsChannelLightPathExcitationDichroicIDKeyRef" refer="OME:DichroicIDKey" ><xsd:selector xpath="OME:Image/OME:Pixels/OME:Channel/OME:LightPath/OME:ExcitationFilterPath/OME:DichroicRef"/><xsd:field xpath="@ID"/></xsd:keyref>
+    <xsd:keyref name="ImagePixelsChannelLightPathDichroicIDKeyRef" refer="OME:DichroicIDKey" ><xsd:selector xpath="OME:Image/OME:Pixels/OME:Channel/OME:LightPath/OME:DichroicRef"/><xsd:field xpath="@ID"/></xsd:keyref>
+    <xsd:keyref name="ImagePixelsChannelLightPathEmissionFilterIDKeyRef" refer="OME:FilterIDKey" ><xsd:selector xpath="OME:Image/OME:Pixels/OME:Channel/OME:LightPath/OME:EmissionFilterPath/OME:FilterRef"/><xsd:field xpath="@ID"/></xsd:keyref>
+    <xsd:keyref name="ImagePixelsChannelLightPathEmissionDichroicIDKeyRef" refer="OME:DichroicIDKey" ><xsd:selector xpath="OME:Image/OME:Pixels/OME:Channel/OME:LightPath/OME:EmissionFilterPath/OME:DichroicRef"/><xsd:field xpath="@ID"/></xsd:keyref>
+    <xsd:keyref name="ImagePixelsChannelLightSourceSettingsLightSourceIDKeyRef" refer="OME:LightSourceIDKey" ><xsd:selector xpath="OME:Image/OME:Pixels/OME:Channel/OME:LightSourceSettings"/><xsd:field xpath="@ID"/></xsd:keyref>
+    <xsd:keyref name="InstrumentFilterSetExcitationFilterIDKeyRef" refer="OME:FilterIDKey" ><xsd:selector xpath="OME:Instrument/OME:FilterSet/OME:ExcitationFilterRef"/><xsd:field xpath="@ID"/></xsd:keyref>
+    <xsd:keyref name="InstrumentFilterSetDichroicIDKeyRef" refer="OME:DichroicIDKey" ><xsd:selector xpath="OME:Instrument/OME:FilterSet/OME:DichroicRef"/><xsd:field xpath="@ID"/></xsd:keyref>
+    <xsd:keyref name="InstrumentFilterSetEmissionFilterIDKeyRef" refer="OME:FilterIDKey" ><xsd:selector xpath="OME:Instrument/OME:FilterSet/OME:EmissionFilterRef"/><xsd:field xpath="@ID"/></xsd:keyref>
+    <xsd:keyref name="InstrumentLightSourceLaserPumpLightSourceIDKey" refer="OME:LightSourceIDKey" ><xsd:selector xpath="OME:Instrument/OME:LightSource/OME:Laser/OME:Pump"/><xsd:field xpath="@ID"/></xsd:keyref>
+    <xsd:keyref name="PlateScreenIDKeyRef" refer="OME:ScreenIDKey" ><xsd:selector xpath="OME:Plate/OME:ScreenRef"/><xsd:field xpath="@ID"/></xsd:keyref>
+    <xsd:keyref name="PlateWellReagentIDKeyRef" refer="OME:ReagentIDKey" ><xsd:selector xpath="OME:Plate/OME:Well/OME:ReagentRef"/><xsd:field xpath="@ID"/></xsd:keyref>
+    <xsd:keyref name="PlateWellWellSampleImageIDKeyRef" refer="OME:ImageIDKey" ><xsd:selector xpath="OME:Plate/OME:Well/OME:WellSample/OME:ImageRef"/><xsd:field xpath="@ID"/></xsd:keyref>
+    <xsd:keyref name="ProjectExperimenterIDKeyRef" refer="OME:ExperimenterIDKey" ><xsd:selector xpath="OME:Project/OME:ExperimenterRef"/><xsd:field xpath="@ID"/></xsd:keyref>
+    <xsd:keyref name="ProjectExperimenterGroupIDKeyRef" refer="OME:ExperimenterGroupIDKey" ><xsd:selector xpath="OME:Project/OME:ExperimenterGroupRef"/><xsd:field xpath="@ID"/></xsd:keyref>
+    <xsd:keyref name="ScreenPlateIDKeyRef" refer="OME:PlateIDKey" ><xsd:selector xpath="OME:Screen/OME:PlateRef"/><xsd:field xpath="@ID"/></xsd:keyref>
+    <xsd:keyref name="ScreenScreenAcquisitionWellSampleIDKeyRef" refer="OME:WellSampleIDKey" ><xsd:selector xpath="OME:Screen/OME:ScreenAcquisition/OME:WellSampleRef"/><xsd:field xpath="@ID"/></xsd:keyref>
+    <xsd:keyref name="ExperimentMicrobeamManipulationROIIDKeyRef" refer="OME:ROIIDKey" ><xsd:selector xpath="OME:Experiment/OME:MicrobeamManipulation/ROIRef"/><xsd:field xpath="@ID"/></xsd:keyref>
+    <xsd:keyref name="ImageROIIDKeyRef" refer="OME:ROIIDKey" ><xsd:selector xpath="OME:Image/ROIRef"/><xsd:field xpath="@ID"/></xsd:keyref>
+    <xsd:keyref name="AnnotationRefAnnotationIDKeyRef" refer="OME:AnnotationIDKey"><xsd:selector xpath=".//OME:AnnotationRef"/><xsd:field xpath="@ID"/></xsd:keyref>
+    <xsd:keyref name="AnnotationAnnotatorExperimenterIDKeyRef" refer="OME:ExperimenterIDKey"><xsd:selector xpath="OME:StructuredAnnotations/*"/><xsd:field xpath="@Annotator"/></xsd:keyref>
+
+  </xsd:element>
+
+  <!-- Key pixel storage elements -->
+  <xsd:element name="Image"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>Images</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        This element describes the actual image and its meta-data.
+        The elements that are references (ending in Ref or Settings) refer to
+        elements defined outside of the Image element. Ref elements are simple
+        links, while Settings elements are links with additional values.
+
+        If any of the required Image attributes or elements are missing, its
+        guaranteed to be an invalid document. The required attributes and
+        elements are ID and Pixels.
+
+        ExperimenterRef is required for all Images with well formed LSIDs.
+        ImageType is a vendor-specific designation of the type of image this is.
+        Examples of ImageType include 'STK', 'SoftWorx', etc.
+        The Name attributes are in all cases the name of the element
+        instance. In this case, the name of the image, not necessarily the filename.
+        Physical size of pixels are microns[µm].
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element name="AcquisitionDate" minOccurs="0" maxOccurs="1" type="xsd:dateTime">
+          <xsd:annotation>
+            <xsd:documentation>
+              The acquisition date of the Image.
+              The element contains an xsd:dateTime string based on the ISO 8601 format (i.e. 1988-04-07T18:39:09.359)
+
+              YYYY-MM-DDTHH:mm:SS.sssZ
+              Y - Year
+              M - Month
+              D - Day
+              H - Hour
+              m - minutes
+              S - Seconds
+              s - sub-seconds (optional)
+              Z - Zone (optional) +HH:mm or -HH:mm or Z for UTC
+
+              Note: xsd:dataTime supports a very wide date range with unlimited precision. The full date range
+              and precision are not typically supported by platform- and language-specific libraries.
+              Where the supported time precision is less than the precision used by the xsd:dateTime
+              timestamp there will be loss of precision; this will typically occur via direct truncation
+              or (less commonly) rounding.
+
+              The year value can be large and/or negative. Any value covering the current or last century
+              should be correctly processed, but some systems cannot process earlier dates.
+
+              The sub-second value is defined as an unlimited number of digits after the decimal point.
+              In Java a minimum of millisecond precision is guaranteed.
+              In C++ microsecond precision is guaranteed, with nanosecond precision being available on
+              some platforms.
+
+              Time zones are supported, eg '2013-10-24T11:52:33+01:00' for Paris, but in most cases it will
+              be converted to UTC when the timestamp is written.
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element ref="ExperimenterRef" minOccurs="0" maxOccurs="1"/>
+        <xsd:element name="Description" minOccurs="0" maxOccurs="1">
+          <xsd:annotation>
+            <xsd:documentation>
+              A description for the image. [plain-text multi-line string]
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:whiteSpace value="preserve"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element ref="ExperimentRef" minOccurs="0" maxOccurs="1"/>
+        <xsd:element ref="ExperimenterGroupRef" minOccurs="0" maxOccurs="1"/>
+        <xsd:element ref="InstrumentRef" minOccurs="0" maxOccurs="1"/>
+        <xsd:element ref="ObjectiveSettings" minOccurs="0" maxOccurs="1"/>
+        <xsd:element ref="ImagingEnvironment" minOccurs="0" maxOccurs="1"/>
+        <xsd:element ref="StageLabel" minOccurs="0" maxOccurs="1"/>
+        <xsd:element ref="Pixels" minOccurs="1" maxOccurs="1"/>
+        <xsd:element ref="ROIRef" minOccurs="0" maxOccurs="unbounded">
+          <xsd:annotation>
+            <xsd:appinfo><xsdfu xmlns=""><manytomany/></xsdfu></xsd:appinfo>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element ref="MicrobeamManipulationRef" minOccurs="0" maxOccurs="unbounded">
+          <xsd:annotation>
+            <xsd:appinfo><xsdfu xmlns=""><manytomany/></xsdfu></xsd:appinfo>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element ref="AnnotationRef" minOccurs="0" maxOccurs="unbounded">
+          <xsd:annotation>
+            <xsd:appinfo><xsdfu xmlns=""><manytomany/></xsdfu></xsd:appinfo>
+          </xsd:annotation>
+        </xsd:element>
+      </xsd:sequence>
+      <xsd:attribute name="ID" use="required" type="ImageID"/>
+      <xsd:attribute name="Name" use="optional" type="xsd:string"/>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="Pixels"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>Pixels</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        Pixels is going to be removed in the future, but it is still required.
+
+        This is just notice that the contents of Pixels will be
+        moved up to Image in a future release. This is because there
+        has only been 1 Pixels object in each Image for some time.
+        The concept of multiple Pixels sets for one Image failed to
+        take off. It is therefore redundant.
+
+        The Image will be unreadable if any of the required Pixel attributes are missing.
+
+        The Pixels themselves can be stored within the OME-XML compressed by plane, and encoded
+        in Base64.
+        Or the Pixels may be stored in TIFF format.
+
+        The Pixels element should contain a list of BinData or TiffData, each containing a
+        single plane of pixels. These Pixels elements, when read in document order,
+        must produce a 5-D pixel array of the size specified in this element, and in the
+        dimension order specified by 'DimensionOrder'.
+
+        All of the values in the Pixels object when present should match the same value
+        stored in any associated TIFF format (e.g. SizeX should be the same). Where there
+        is a mismatch our readers will take the value from the TIFF structure as overriding
+        the value in the OME-XML. This is simply a pragmatic decision as it increases the
+        likelihood of reading data from a slightly incorrect file.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="Channel" minOccurs="0" maxOccurs="unbounded">
+          <xsd:annotation>
+            <xsd:appinfo><xsdfu xmlns=""><ordered/></xsdfu></xsd:appinfo>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:choice minOccurs="1" maxOccurs="1">
+          <xsd:element ref="BinData" minOccurs="1" maxOccurs="unbounded"/>
+          <xsd:element ref="TiffData" minOccurs="1" maxOccurs="unbounded"/>
+          <xsd:element ref="MetadataOnly" minOccurs="1" maxOccurs="1"/>
+        </xsd:choice>
+        <xsd:element ref="Plane" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="ID" use="required" type="PixelsID"/>
+      <xsd:attribute name="DimensionOrder" use="required">
+        <xsd:annotation>
+          <xsd:documentation>
+            The order in which the individual planes of data are interleaved.
+          </xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleType>
+          <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="XYZCT"/>
+            <xsd:enumeration value="XYZTC"/>
+            <xsd:enumeration value="XYCTZ"/>
+            <xsd:enumeration value="XYCZT"/>
+            <xsd:enumeration value="XYTCZ"/>
+            <xsd:enumeration value="XYTZC"/>
+          </xsd:restriction>
+        </xsd:simpleType>
+      </xsd:attribute>
+      <xsd:attribute name="Type" use="required" type="PixelType">
+        <xsd:annotation>
+          <xsd:documentation>
+            The variable type used to represent each pixel in the image.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="SignificantBits" use="optional" type="PositiveInt">
+        <xsd:annotation>
+          <xsd:documentation>
+            The number of bits within the type storing each pixel that are significant.
+            e.g. you can store 12 bit data within a 16 bit type.
+            This does not reduce the storage requirements but can be a useful indicator
+            when processing or viewing the image data.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="Interleaved" use="optional" type="xsd:boolean">
+        <xsd:annotation>
+          <xsd:documentation>
+            How the channels are arranged within the data block:
+            true if channels are stored RGBRGBRGB...;
+            false if channels are stored RRR...GGG...BBB...
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="BigEndian" use="optional" type="xsd:boolean">
+        <xsd:annotation>
+          <xsd:documentation>
+            This is true if the pixels data was written in BigEndian order.
+
+            If this value is present it should match the value used in BinData
+            or TiffData. If it does not a reader should honour the value used
+            in the BinData or TiffData. This values is useful for MetadataOnly
+            files and is to allow for future storage solutions.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="SizeX" use="required" type="PositiveInt">
+        <xsd:annotation>
+          <xsd:documentation>Dimensional size of pixel data array [units:none]</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="SizeY" use="required" type="PositiveInt">
+        <xsd:annotation>
+          <xsd:documentation>Dimensional size of pixel data array [units:none]</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="SizeZ" use="required" type="PositiveInt">
+        <xsd:annotation>
+          <xsd:documentation>Dimensional size of pixel data array [units:none]</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="SizeC" use="required" type="PositiveInt">
+        <xsd:annotation>
+          <xsd:documentation>Dimensional size of pixel data array [units:none]</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="SizeT" use="required" type="PositiveInt">
+        <xsd:annotation>
+          <xsd:documentation>Dimensional size of pixel data array [units:none]</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="PhysicalSizeX" use="optional" type="PositiveFloat">
+        <xsd:annotation>
+          <xsd:documentation>Physical size of a pixel. Units are set by PhysicalSizeXUnit.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="PhysicalSizeXUnit" use="optional" default="µm" type="UnitsLength">
+        <xsd:annotation>
+          <xsd:documentation>The units of the physical size of a pixel - default:microns[µm].</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="PhysicalSizeY" use="optional" type="PositiveFloat">
+        <xsd:annotation>
+          <xsd:documentation>Physical size of a pixel. Units are set by PhysicalSizeYUnit.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="PhysicalSizeYUnit" use="optional" default="µm" type="UnitsLength">
+        <xsd:annotation>
+          <xsd:documentation>The units of the physical size of a pixel - default:microns[µm].</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="PhysicalSizeZ" use="optional" type="PositiveFloat">
+        <xsd:annotation>
+          <xsd:documentation>Physical size of a pixel. Units are set by PhysicalSizeZUnit.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="PhysicalSizeZUnit" use="optional" default="µm" type="UnitsLength">
+        <xsd:annotation>
+          <xsd:documentation>The units of the physical size of a pixel - default:microns[µm].</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="TimeIncrement" use="optional" type="xsd:float">
+        <xsd:annotation>
+          <xsd:documentation>
+            TimeIncrement is used for time series that have a global
+            timing specification instead of per-timepoint timing info.
+            For example in a video stream. Units are set by TimeIncrementUnit.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="TimeIncrementUnit" use="optional" default="s" type="UnitsTime">
+        <xsd:annotation>
+          <xsd:documentation>The units of the TimeIncrement - default:seconds[s].</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="Plane"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>Planes</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        The Plane object holds microscope stage and image timing data
+        for a given channel/z-section/timepoint.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:choice minOccurs="0" maxOccurs="1">
+          <xsd:annotation>
+            <xsd:documentation>
+              This optional element is a hash of the plane's image data.
+              It is a choice between all the support hash types.
+              Currently the only method supported is SHA1.
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:element name="HashSHA1" type="Hex40" minOccurs="1" maxOccurs="1"/>
+        </xsd:choice>
+        <xsd:element ref="AnnotationRef" minOccurs="0" maxOccurs="unbounded">
+          <xsd:annotation>
+            <xsd:appinfo><xsdfu xmlns=""><manytomany/></xsdfu></xsd:appinfo>
+          </xsd:annotation>
+        </xsd:element>
+      </xsd:sequence>
+      <xsd:attribute name="TheZ" use="required" type="NonNegativeInt">
+        <xsd:annotation>
+          <xsd:documentation>
+            The Z-section this plane is for. [units:none]
+            This is numbered from 0.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="TheT" use="required" type="NonNegativeInt">
+        <xsd:annotation>
+          <xsd:documentation>
+            The timepoint this plane is for. [units:none]
+            This is numbered from 0.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="TheC" use="required" type="NonNegativeInt">
+        <xsd:annotation>
+          <xsd:documentation>
+            The channel this plane is for. [units:none]
+            This is numbered from 0.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="DeltaT" use="optional" type="xsd:float">
+        <xsd:annotation>
+          <xsd:documentation>
+            Time since the beginning of the experiment.
+            Units are set by DeltaTUnit.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="DeltaTUnit" use="optional" default="s" type="UnitsTime">
+        <xsd:annotation>
+          <xsd:documentation>The units of the DeltaT - default:seconds[s].</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="ExposureTime" use="optional" type="xsd:float">
+        <xsd:annotation>
+          <xsd:documentation>
+            The length of the exposure.
+            Units are set by ExposureTimeUnit.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="ExposureTimeUnit" use="optional" default="s" type="UnitsTime">
+        <xsd:annotation>
+          <xsd:documentation>The units of the ExposureTime - default:seconds[s].</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="PositionX" use="optional" type="xsd:float">
+        <xsd:annotation>
+          <xsd:documentation>
+            The X position of the stage. Units are set by PositionXUnit.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="PositionXUnit" use="optional" default="reference frame" type="UnitsLength">
+        <xsd:annotation>
+          <xsd:documentation>The units of the X stage position - default:[reference frame].</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="PositionY" use="optional" type="xsd:float">
+        <xsd:annotation>
+          <xsd:documentation>
+            The Y position of the stage. Units are set by PositionYUnit.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="PositionYUnit" use="optional" default="reference frame" type="UnitsLength">
+        <xsd:annotation>
+          <xsd:documentation>The units of the Y stage position - default:[reference frame].</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="PositionZ" use="optional" type="xsd:float">
+        <xsd:annotation>
+          <xsd:documentation>
+            The Z position of the stage. Units are set by PositionZUnit.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="PositionZUnit" use="optional" default="reference frame" type="UnitsLength">
+        <xsd:annotation>
+          <xsd:documentation>The units of the Z stage position - default:[reference frame].</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="Channel"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>Channels</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        There must be one per channel in the Image, even for a single-plane image.
+        And information about how each of them was acquired is stored in the various optional *Ref elements.  Each Logical Channel is composed of one or more
+        ChannelComponents.  For example, an entire spectrum in an FTIR experiment may be stored in a single Logical Channel with each discrete wavenumber of the spectrum
+        constituting a ChannelComponent of the FTIR Logical Channel.  An RGB image where the Red, Green and Blue components do not reflect discrete probes but are
+        instead the output of a color camera would be treated similarly - one Logical channel with three ChannelComponents in this case.
+        The total number of ChannelComponents for a set of pixels must equal SizeC.
+        The IlluminationType attribute is a string enumeration which may be set to 'Transmitted', 'Epifluorescence', 'Oblique', or 'NonLinear'.
+        The user interface logic for labeling a given channel for the user should use the first existing attribute in the following sequence:
+        Name -> Fluor -> EmissionWavelength -> ChannelComponent/Index.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="LightSourceSettings" minOccurs="0" maxOccurs="1"/>
+        <xsd:element ref="DetectorSettings" minOccurs="0" maxOccurs="1"/>
+        <xsd:element ref="FilterSetRef" minOccurs="0" maxOccurs="1"/>
+        <xsd:element ref="AnnotationRef" minOccurs="0" maxOccurs="unbounded">
+          <xsd:annotation>
+            <xsd:appinfo><xsdfu xmlns=""><manytomany/></xsdfu></xsd:appinfo>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element ref="LightPath" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+      <xsd:attribute name="ID" use="required" type="ChannelID"/>
+      <xsd:attribute name="Name" use="optional" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            A name for the channel that is suitable for presentation to the user.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="SamplesPerPixel" use="optional" type="PositiveInt">
+        <xsd:annotation>
+          <xsd:documentation>
+            The number of samples the detector takes to form each pixel value. [units:none]
+            Note: This is not the same as "Frame Averaging" - see Integration in DetectorSettings
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="IlluminationType" use="optional">
+        <xsd:annotation>
+          <xsd:documentation>
+            The method of illumination used to capture the channel.
+          </xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleType>
+          <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="Transmitted"/>
+            <xsd:enumeration value="Epifluorescence"/>
+            <xsd:enumeration value="Oblique"/>
+            <xsd:enumeration value="NonLinear"/>
+            <xsd:enumeration value="Other"/>
+          </xsd:restriction>
+        </xsd:simpleType>
+      </xsd:attribute>
+      <xsd:attribute name="PinholeSize" use="optional" type="xsd:float">
+        <xsd:annotation>
+          <xsd:documentation>
+            The optional PinholeSize attribute allows specifying adjustable
+            pin hole diameters for confocal microscopes. Units are set by PinholeSizeUnit.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="PinholeSizeUnit" use="optional" default="µm" type="UnitsLength">
+        <xsd:annotation>
+          <xsd:documentation>The units of the pin hole diameter for confocal microscopes - default:microns[µm].</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="AcquisitionMode" use="optional">
+        <xsd:annotation>
+          <xsd:documentation>
+            AcquisitionMode describes the type of microscopy performed for each channel
+          </xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleType>
+          <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="WideField"/>
+            <xsd:enumeration value="LaserScanningConfocalMicroscopy"/> <!-- CLSM or LSCM -->
+            <xsd:enumeration value="SpinningDiskConfocal"/>
+            <xsd:enumeration value="SlitScanConfocal"/>
+            <xsd:enumeration value="MultiPhotonMicroscopy"/><!-- laser scanning multiphoton microscopy (LSMM), two photon microscopy -->
+            <xsd:enumeration value="StructuredIllumination"/>
+            <xsd:enumeration value="SingleMoleculeImaging"/>
+            <xsd:enumeration value="TotalInternalReflection"/>
+            <xsd:enumeration value="FluorescenceLifetime"/>
+            <xsd:enumeration value="SpectralImaging"/>
+            <xsd:enumeration value="FluorescenceCorrelationSpectroscopy"/>
+            <xsd:enumeration value="NearFieldScanningOpticalMicroscopy"/><!-- NSOM -->
+            <xsd:enumeration value="SecondHarmonicGenerationImaging"/><!-- Second harmonic imaging microscopy (SHIM) -->
+            <xsd:enumeration value="PALM"/><!-- photo-activated localization microscopy, photo-activation localization microscopy -->
+            <xsd:enumeration value="STORM"/><!-- stochastic optical reconstruction microscopy -->
+            <xsd:enumeration value="STED"/><!-- stimulated emission depletion -->
+            <xsd:enumeration value="TIRF"/><!-- total internal reflection fluorescence (TIRFM) -->
+            <xsd:enumeration value="FSM"/><!-- Fluorescence speckle microscopy -->
+            <xsd:enumeration value="LCM"/><!-- Laser capture microdissection -->
+            <xsd:enumeration value="Other"/>
+            <xsd:enumeration value="BrightField"/>
+            <xsd:enumeration value="SweptFieldConfocal"/>
+            <xsd:enumeration value="SPIM"/><!-- Selective or Single Plane Illumination Microscopy -->
+          </xsd:restriction>
+        </xsd:simpleType>
+      </xsd:attribute>
+      <xsd:attribute name="ContrastMethod" use="optional">
+        <xsd:annotation>
+          <xsd:documentation>
+            ContrastMethod describes the technique used to achieve contrast for each channel
+          </xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleType>
+          <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="Brightfield"/>
+            <xsd:enumeration value="Phase"/>
+            <xsd:enumeration value="DIC"/><!-- Differential Interference Contrast -->
+            <xsd:enumeration value="HoffmanModulation"/><!-- Hoffman Modulation Contrast (HMC) -->
+            <xsd:enumeration value="ObliqueIllumination"/>
+            <xsd:enumeration value="PolarizedLight"/> <!-- Polarization Microscopy -->
+            <xsd:enumeration value="Darkfield"/><!-- Dark Field Imaging -->
+            <xsd:enumeration value="Fluorescence"/>
+            <xsd:enumeration value="Other"/>
+          </xsd:restriction>
+        </xsd:simpleType>
+      </xsd:attribute>
+      <xsd:attribute name="ExcitationWavelength" use="optional" type="PositiveFloat">
+        <xsd:annotation>
+          <xsd:documentation>
+            Wavelength of excitation for a particular channel. Units are set by ExcitationWavelengthUnit.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="ExcitationWavelengthUnit" use="optional" default="nm" type="UnitsLength">
+        <xsd:annotation>
+          <xsd:documentation>The units of the wavelength of excitation - default:nanometres[nm].</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="EmissionWavelength" use="optional" type="PositiveFloat">
+        <xsd:annotation>
+          <xsd:documentation>
+            Wavelength of emission for a particular channel. Units are set by EmissionWavelengthUnit.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="EmissionWavelengthUnit" use="optional" default="nm" type="UnitsLength">
+        <xsd:annotation>
+          <xsd:documentation>The units of the wavelength of emission - default:nanometres[nm].</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="Fluor" use="optional" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            The Fluor attribute is used for fluorescence images.
+            This is the name of the fluorophore used to produce this channel [plain text string]
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="NDFilter" use="optional" type="xsd:float">
+        <xsd:annotation>
+          <xsd:documentation>
+            The NDfilter attribute is used to specify the combined effect of any neutral density filters used.
+            The amount of light the filter transmits at a maximum [units:none]
+            A fraction, as a value from 0.0 to 1.0.
+
+            NOTE: This was formerly described as "units optical density expressed as a PercentFraction".
+            This was how the field had been described in the schema from the beginning but all
+            the use of it has been in the opposite direction, i.e. as a amount transmitted,
+            not the amount blocked. This change has been made to make the model reflect this usage.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="PockelCellSetting" use="optional" type="xsd:int">
+        <xsd:annotation>
+          <xsd:documentation>
+            The PockelCellSetting used for this channel. This is the amount the polarization of the beam is rotated by. [units:none]
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="Color" use="optional" type="Color" default="-1">
+        <xsd:annotation>
+          <xsd:documentation>
+            A color used to render this channel - encoded as RGBA
+            The default value "-1" is #FFFFFFFF so solid white (it is a signed 32 bit value)
+            NOTE: Prior to the 2012-06 schema the default value was incorrect and produced a transparent red not solid white.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- Other elements associated with pixel storage -->
+  <xsd:element name="MetadataOnly"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>MetadataOnlyMarkers</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        This place holder means there is no pixel data in this file.
+      </xsd:documentation>
+    </xsd:annotation>
+  </xsd:element>
+  <xsd:element name="TiffData"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>TiffDataBlocks</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        This describes the location of the pixel data in a tiff file.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element name="UUID" minOccurs="0" maxOccurs="1">
+          <xsd:annotation>
+            <xsd:documentation>
+              This must be used when the IFDs are located in another file.
+              Note: It is permissible for this to be self referential.
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:complexType>
+            <xsd:simpleContent>
+              <xsd:extension base = "UniversallyUniqueIdentifier">
+                <xsd:attribute name="FileName" use="optional" type="xsd:string">
+                  <xsd:annotation>
+                    <xsd:documentation>
+                      This can be used when the IFDs are located in another file.
+                      The / (forward slash) is used as the path separator.
+                      A relative path is recommended. However an absolute path can be specified.
+                      Default is to use the file the ome-xml data has been pulled from.
+                      Note: It is permissible for this to be self referential. The file image1.tiff
+                      may contain ome-xml data that has FilePath="image1.tiff" or "./image1.tiff"
+                    </xsd:documentation>
+                  </xsd:annotation>
+                </xsd:attribute>
+              </xsd:extension>
+            </xsd:simpleContent>
+          </xsd:complexType>
+        </xsd:element>
+      </xsd:sequence>
+      <xsd:attribute name="IFD" type="NonNegativeInt" default="0" use="optional">
+        <xsd:annotation>
+          <xsd:documentation>
+            Gives the IFD(s) for which this element is applicable. Indexed from 0.
+            Default is 0 (the first IFD). [units:none]
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="FirstZ" type="NonNegativeInt" default="0" use="optional">
+        <xsd:annotation>
+          <xsd:documentation>
+            Gives the Z position of the image plane at the specified IFD. Indexed from 0.
+            Default is 0 (the first Z position). [units:none]
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="FirstT" type="NonNegativeInt" default="0" use="optional">
+        <xsd:annotation>
+          <xsd:documentation>
+            Gives the T position of the image plane at the specified IFD. Indexed from 0.
+            Default is 0 (the first T position). [units:none]
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="FirstC" type="NonNegativeInt" default="0" use="optional">
+        <xsd:annotation>
+          <xsd:documentation>
+            Gives the C position of the image plane at the specified IFD. Indexed from 0.
+            Default is 0 (the first C position). [units:none]
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="PlaneCount" use="optional" type="NonNegativeInt">
+        <xsd:annotation>
+          <xsd:documentation>
+            Gives the number of IFDs affected. Dimension order of IFDs is given by the enclosing
+            Pixels element's DimensionOrder attribute. Default is the number of IFDs in the TIFF
+            file, unless an IFD is specified, in which case the default is 1. [units:none]
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="StageLabel"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>StageLabels</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        The StageLabel is used to specify a name and position for a stage position in the microscope's reference frame.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:attribute name="Name" use="required" type="xsd:string"/>
+      <xsd:attribute name="X" use="optional" type="xsd:float">
+        <xsd:annotation>
+          <xsd:documentation>
+            The X position of the stage label. Units are set by XUnit.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="XUnit" use="optional" default="reference frame" type="UnitsLength">
+        <xsd:annotation>
+          <xsd:documentation>The units of the X stage position - default:[reference frame].</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="Y" use="optional" type="xsd:float">
+        <xsd:annotation>
+          <xsd:documentation>
+            The Y position of the stage label. Units are set by YUnit.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="YUnit" use="optional" default="reference frame" type="UnitsLength">
+        <xsd:annotation>
+          <xsd:documentation>The units of the Y stage position - default:[reference frame].</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="Z" use="optional" type="xsd:float">
+        <xsd:annotation>
+          <xsd:documentation>
+            The Z position of the stage label. Units are set by ZUnit.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="ZUnit" use="optional" default="reference frame" type="UnitsLength">
+        <xsd:annotation>
+          <xsd:documentation>The units of the Z  stage position - default:[reference frame].</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- Misc -->
+  <xsd:element name="MicrobeamManipulation"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>MicrobeamManipulations</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        Defines a microbeam operation type and the region of the image it was applied to.
+        The LightSourceRef element is a reference to a LightSource specified in the Instrument element which was used for a technique other than illumination for
+        the purpose of imaging. For example, a laser used for photobleaching.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element name="Description" minOccurs="0" maxOccurs="1">
+          <xsd:annotation>
+            <xsd:documentation>
+              A description for the Microbeam Manipulation. [plain-text multi-line string]
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:whiteSpace value="preserve"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element ref="ROIRef" minOccurs="1" maxOccurs="unbounded">
+          <xsd:annotation>
+            <xsd:appinfo><xsdfu xmlns=""><manytomany/></xsdfu></xsd:appinfo>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element ref="ExperimenterRef" minOccurs="1" maxOccurs="1"/>
+        <xsd:element ref="LightSourceSettings" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="ID" use="required" type="MicrobeamManipulationID"/>
+      <xsd:attribute name="Type" use="optional">
+        <xsd:annotation>
+          <xsd:documentation>
+            The type of manipulation performed.
+          </xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleType>
+          <xsd:list>
+            <xsd:simpleType>
+              <xsd:restriction base="xsd:string">
+                <xsd:enumeration value="FRAP"/><!-- Fluorescence recovery after photobleaching -->
+                <xsd:enumeration value="FLIP"/><!-- Fluorescence Loss in Photobleaching -->
+                <xsd:enumeration value="InverseFRAP"/><!-- iFRAP, inverse FRAP -->
+                <xsd:enumeration value="Photoablation"/>
+                <xsd:enumeration value="Photoactivation"/>
+                <xsd:enumeration value="Uncaging"/>
+                <xsd:enumeration value="OpticalTrapping"/>
+                <xsd:enumeration value="Other"/>
+              </xsd:restriction>
+            </xsd:simpleType>
+          </xsd:list>
+        </xsd:simpleType>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- Physical microscope elements -->
+  <xsd:element name="Instrument"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>Instruments</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        This element describes the instrument used to capture the Image.
+        It is primarily a container for manufacturer's model and catalog
+        numbers for the Microscope, LightSource, Detector, Objective and
+        Filters components.
+        The Objective element contains the additional elements LensNA and Magnification.
+        The Filters element can be composed either of separate excitation,
+        emission filters and a dichroic mirror or a single filter set.
+        Within the Image itself, a reference is made to this one Filter element.
+        There may be multiple light sources, detectors, objectives and filters on a microscope.
+        Each of these has their own ID attribute, which can be referred to from Channel.
+        It is understood that the light path configuration can be different
+        for each channel, but cannot be different for each timepoint or
+        each plane of an XYZ stack.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="Microscope" minOccurs="0" maxOccurs="1"/>
+        <xsd:element ref="LightSourceGroup" minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element ref="Detector" minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element ref="Objective" minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element ref="FilterSet" minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element ref="Filter" minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element ref="Dichroic" minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element ref="AnnotationRef" minOccurs="0" maxOccurs="unbounded">
+          <xsd:annotation>
+            <xsd:appinfo><xsdfu xmlns=""><manytomany/></xsdfu></xsd:appinfo>
+          </xsd:annotation>
+        </xsd:element>
+      </xsd:sequence>
+      <xsd:attribute name="ID" use="required" type="InstrumentID"/>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="Microscope"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>Microscopes</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>The microscope's manufacturer specification.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="ManufacturerSpec">
+          <xsd:attribute name="Type" use="optional">
+            <xsd:simpleType>
+              <xsd:restriction base="xsd:string">
+                <xsd:enumeration value="Upright"/>
+                <xsd:enumeration value="Inverted"/>
+                <xsd:enumeration value="Dissection"/>
+                <xsd:enumeration value="Electrophysiology"/>
+                <xsd:enumeration value="Other"/>
+              </xsd:restriction>
+            </xsd:simpleType>
+          </xsd:attribute>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- Image sample elements -->
+  <xsd:element name="ImagingEnvironment"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>ImagingEnvironments</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        This describes the environment that the biological sample was in
+        during the experiment.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element name="Map" type="Map" minOccurs="0" maxOccurs="1"/>
+      </xsd:sequence>
+      <xsd:attribute name="Temperature" use="optional" type="xsd:float">
+        <xsd:annotation>
+          <xsd:documentation>
+            The Temperature is the define units.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="TemperatureUnit" use="optional" default="°C" type="UnitsTemperature">
+        <xsd:annotation>
+          <xsd:documentation>
+            The units the Temperature is in - default:Celsius[°C].
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="AirPressure" use="optional" type="xsd:float">
+        <xsd:annotation>
+          <xsd:documentation>
+            AirPressure is the define units.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="AirPressureUnit" use="optional" default="mbar" type="UnitsPressure">
+        <xsd:annotation>
+          <xsd:documentation>
+            The units the AirPressure is in - default:millibars[mbar].
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="Humidity" use="optional" type="PercentFraction">
+        <xsd:annotation>
+          <xsd:documentation>
+            Humidity around the sample [units:none]
+            A fraction, as a value from 0.0 to 1.0.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="CO2Percent" use="optional" type="PercentFraction">
+        <xsd:annotation>
+          <xsd:documentation>
+            Carbon Dioxide concentration around the sample [units:none]
+            A fraction, as a value from 0.0 to 1.0.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- Structure elements -->
+  <xsd:element name="Project"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>Projects</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        The Project ID is required.
+        Datasets can be grouped into projects using a many-to-many relationship.
+        A Dataset may belong to one or more Projects by including one or more ProjectRef elements which refer to Project IDs.
+        Projects do not directly contain images - only by virtue of containing datasets, which themselves contain images.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element name="Description" minOccurs="0" maxOccurs="1">
+          <xsd:annotation>
+            <xsd:documentation>
+              A description for the project. [plain-text multi-line string]
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:whiteSpace value="preserve"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element ref="ExperimenterRef" minOccurs="0" maxOccurs="1"/>
+        <xsd:element ref="ExperimenterGroupRef" minOccurs="0" maxOccurs="1"/>
+        <xsd:element ref="DatasetRef" minOccurs="0" maxOccurs="unbounded">
+          <xsd:annotation>
+            <xsd:appinfo><xsdfu xmlns=""><manytomany/></xsdfu></xsd:appinfo>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element ref="AnnotationRef" minOccurs="0" maxOccurs="unbounded">
+          <xsd:annotation>
+            <xsd:appinfo><xsdfu xmlns=""><manytomany/></xsdfu></xsd:appinfo>
+          </xsd:annotation>
+        </xsd:element>
+      </xsd:sequence>
+      <xsd:attribute name="Name" use="optional" type="xsd:string"/>
+      <xsd:attribute name="ID" use="required" type="ProjectID"/>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="ExperimenterGroup"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>ExperimenterGroups</plural><global/></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        The ExperimenterGroupID is required.
+        Information should ideally be specified for at least one Leader as a contact for the group.
+        The Leaders are themselves Experimenters.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element name="Description" minOccurs="0" maxOccurs="1">
+          <xsd:annotation>
+            <xsd:documentation>
+              A description for the group. [plain-text multi-line string]
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:whiteSpace value="preserve"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element ref="ExperimenterRef" minOccurs="0" maxOccurs="unbounded">
+          <xsd:annotation>
+            <xsd:appinfo><xsdfu xmlns=""><manytomany/><childordered/></xsdfu></xsd:appinfo>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element ref="Leader" minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element ref="AnnotationRef" minOccurs="0" maxOccurs="unbounded">
+          <xsd:annotation>
+            <xsd:appinfo><xsdfu xmlns=""><manytomany/></xsdfu></xsd:appinfo>
+          </xsd:annotation>
+        </xsd:element>
+      </xsd:sequence>
+      <xsd:attribute name="Name" use="optional" type="xsd:string">
+        <xsd:annotation>
+          <xsd:appinfo><xsdfu xmlns=""><unique/></xsdfu></xsd:appinfo>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="ID" use="required" type="ExperimenterGroupID"/>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="Leader"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>Leaders</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        Contact information for a ExperimenterGroup leader specified using a reference
+        to an Experimenter element defined elsewhere in the document.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="Reference">
+          <xsd:attribute name="ID" use="required" type="ExperimenterID"/>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="Dataset"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>Datasets</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        An element specifying a collection of images that are always processed together.
+        Images can belong to more than one Dataset, and a Dataset may contain more than one Image.
+        Images contain one or more DatasetRef elements to specify what datasets they belong to.
+        Once a Dataset has been processed in any way, its collection of images cannot be altered.
+        The ExperimenterRef and ExperimenterGroupRef elements specify the person and group this Dataset belongs to.
+        Projects may contain one or more Datasets, and Datasets may belong to one or more Projects.
+        This relationship is specified by listing DatasetRef elements within the Project element.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element name="Description" minOccurs="0" maxOccurs="1">
+          <xsd:annotation>
+            <xsd:documentation>
+              A description for the dataset. [plain-text multi-line string]
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:whiteSpace value="preserve"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element ref="ExperimenterRef" minOccurs="0" maxOccurs="1"/>
+        <xsd:element ref="ExperimenterGroupRef" minOccurs="0" maxOccurs="1"/>
+        <xsd:element ref="ImageRef" minOccurs="0" maxOccurs="unbounded">
+          <xsd:annotation>
+            <xsd:appinfo><xsdfu xmlns=""><manytomany/></xsdfu></xsd:appinfo>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element ref="AnnotationRef" minOccurs="0" maxOccurs="unbounded">
+          <xsd:annotation>
+            <xsd:appinfo><xsdfu xmlns=""><manytomany/></xsdfu></xsd:appinfo>
+          </xsd:annotation>
+        </xsd:element>
+      </xsd:sequence>
+      <xsd:attribute name="Name" use="optional" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            A name for the dataset that is suitable for presentation to the user.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="ID" use="required" type="DatasetID"/>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="Experiment"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>Experiments</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        This element describes the type of experiment.  The required Type attribute must contain one or more entries from the following list:
+        FP FRET Time-lapse 4-D+ Screen Immunocytochemistry FISH Electrophysiology  Ion-Imaging Colocalization PGI/Documentation
+        FRAP Photoablation Optical-Trapping Photoactivation Fluorescence-Lifetime Spectral-Imaging Other
+        FP refers to fluorescent proteins, PGI/Documentation is not a 'data' image.
+        The optional Description element may contain free text to further describe the experiment.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element name="Description" minOccurs="0" maxOccurs="1">
+          <xsd:annotation>
+            <xsd:documentation>
+              A description for the experiment. [plain-text multi-line string]
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:whiteSpace value="preserve"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element ref="ExperimenterRef" minOccurs="0" maxOccurs="1">
+          <xsd:annotation>
+            <xsd:documentation>
+              This is a link to the Experimenter who conducted the experiment
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element ref="MicrobeamManipulation" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="Type" use="optional">
+        <xsd:annotation>
+          <xsd:documentation>
+            A term to describe the type of experiment.
+          </xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleType>
+          <xsd:list>
+            <xsd:simpleType>
+              <xsd:restriction base="xsd:string">
+                <xsd:enumeration value="FP"/>
+                <xsd:enumeration value="FRET"/><!-- Förster resonance energy transfer, also known as fluorescence resonance energy transfer, resonance energy transfer (RET) or electronic energy transfer (EET) -->
+                <xsd:enumeration value="TimeLapse"/><!--  Time-lapse microscopy (microphotography, photomicrography) -->
+                <xsd:enumeration value="FourDPlus"/>
+                <xsd:enumeration value="Screen"/>
+                <xsd:enumeration value="Immunocytochemistry"/>
+                <xsd:enumeration value="Immunofluorescence"/>
+                <xsd:enumeration value="FISH"/><!-- Fluorescent in situ hybridization -->
+                <xsd:enumeration value="Electrophysiology"/>
+                <xsd:enumeration value="IonImaging"/>
+                <xsd:enumeration value="Colocalization"/>
+                <xsd:enumeration value="PGIDocumentation"/>
+                <xsd:enumeration value="FluorescenceLifetime"/><!-- Fluorescence lifetime imaging (FLIM) -->
+                <xsd:enumeration value="SpectralImaging"/>
+                <xsd:enumeration value="Photobleaching"/>
+                <xsd:enumeration value="SPIM"/><!-- Selective or Single Plane Illumination Microscopy -->
+                <xsd:enumeration value="Other"/>
+              </xsd:restriction>
+            </xsd:simpleType>
+          </xsd:list>
+        </xsd:simpleType>
+      </xsd:attribute>
+      <xsd:attribute name="ID" use="required" type="ExperimentID"/>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="Experimenter"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>Experimenters</plural><global/></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        This element describes a person who performed an imaging experiment.
+        This person may also be a user of the OME system, in which case the UserName element contains their login name.
+        Experimenters may belong to one or more groups which are specified using one or more ExperimenterGroupRef elements.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="AnnotationRef" minOccurs="0" maxOccurs="unbounded">
+          <xsd:annotation>
+            <xsd:appinfo><xsdfu xmlns=""><manytomany/></xsdfu></xsd:appinfo>
+          </xsd:annotation>
+        </xsd:element>
+      </xsd:sequence>
+      <xsd:attribute name="ID" use="required" type="ExperimenterID"/>
+      <xsd:attribute name="FirstName" use="optional" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>First name, sometime called christian name or given name or forename. [plain text string]</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="MiddleName" use="optional" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>Any other names. [plain text string]</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="LastName" use="optional" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>A person's last name sometimes called surname or family name. [plain text string]</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="Email" use="optional" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>A person's email address. [valid email address as string]</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="Institution" use="optional" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            A person's Institution
+            The organizing structure that people belong to other than groups.  A university, or company, etc.
+            We do not specify a department element, and do not mean for Institution to be used in this way.
+            We simply wish to say XXX at YYY.  Where YYY has a better chance of being tied to a geographically fixed location
+            and of being more recognizable than a group of experimenters. [plain text string]
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="UserName" use="optional" type="xsd:string">
+        <xsd:annotation>
+          <xsd:appinfo><xsdfu xmlns=""><unique/></xsdfu></xsd:appinfo>
+          <xsd:documentation>This is the username of the experimenter (in a 'unix' or 'database' sense). [plain text string]</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="Folder"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>Folders</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        An element specifying a possibly heterogeneous collection of data.
+        Folders may contain Folders so that data may be organized within a tree of Folders.
+        Data may be in multiple Folders but a Folder may not be in more than one other Folder.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element name="Description" minOccurs="0" maxOccurs="1">
+          <xsd:annotation>
+            <xsd:documentation>
+              A description for the folder. [plain-text multi-line string]
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:whiteSpace value="preserve"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element ref="FolderRef" minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element ref="ImageRef" minOccurs="0" maxOccurs="unbounded">
+          <xsd:annotation>
+            <xsd:appinfo><xsdfu xmlns=""><manytomany/></xsdfu></xsd:appinfo>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element ref="ROIRef" minOccurs="0" maxOccurs="unbounded">
+          <xsd:annotation>
+            <xsd:appinfo><xsdfu xmlns=""><manytomany/></xsdfu></xsd:appinfo>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element ref="AnnotationRef" minOccurs="0" maxOccurs="unbounded">
+          <xsd:annotation>
+            <xsd:appinfo><xsdfu xmlns=""><manytomany/></xsdfu></xsd:appinfo>
+          </xsd:annotation>
+        </xsd:element>
+      </xsd:sequence>
+      <xsd:attribute name="ID" use="required" type="FolderID"/>
+      <xsd:attribute name="Name" use="optional" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            A name for the folder that is suitable for presentation to the user.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- Common types -->
+  <xsd:complexType name="ManufacturerSpec">
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><abstract/></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        This is the base from which many microscope components are extended. E.g Objective, Filter etc.
+        Provides attributes for recording common properties of these components such as Manufacturer name, Model etc,
+        all of which are optional.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="Manufacturer" use="optional" type="xsd:string">
+      <xsd:annotation>
+        <xsd:documentation>
+          The manufacturer of the component. [plain text string]
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="Model" use="optional" type="xsd:string">
+      <xsd:annotation>
+        <xsd:documentation>
+          The Model of the component. [plain text string]
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="SerialNumber" use="optional" type="xsd:string">
+      <xsd:annotation>
+        <xsd:documentation>
+          The serial number of the component. [plain text string]
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="LotNumber" use="optional" type="xsd:string">
+      <xsd:annotation>
+        <xsd:documentation>
+          The lot number of the component. [plain text string]
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+  </xsd:complexType>
+  <xsd:simpleType name="Hex40">
+    <xsd:annotation>
+      <xsd:documentation>
+        Binary contents coded in hexadecimal (20 characters long)
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:hexBinary">
+      <xsd:length value="20"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="NonNegativeFloat">
+    <xsd:annotation>
+      <xsd:documentation>
+        A simple type that restricts the value to a float between >=0 and max 32-bit float {i.e. (2−2^-23) × 2^27 ≈ 3.4 × 10^38}
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:float">
+      <xsd:minInclusive value="0"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="NonNegativeLong">
+    <xsd:annotation>
+      <xsd:documentation>
+        A simple type that restricts the value to a long between 0 and 9223372036854775807 (inclusive).
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:long">
+      <xsd:minInclusive value="0"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="NonNegativeInt">
+    <xsd:annotation>
+      <xsd:documentation>
+        A simple type that restricts the value to an integer between 0 and 2,147,483,647 (inclusive).
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:int">
+      <xsd:minInclusive value="0"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="PositiveInt">
+    <xsd:annotation>
+      <xsd:documentation>
+        A simple type that restricts the value to an integer between 1 and 2,147,483,647 (inclusive).
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:int">
+      <xsd:minInclusive value="1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="PositiveFloat">
+    <xsd:annotation>
+      <xsd:documentation>
+        A simple type that restricts the value to a float between >0 and max 32-bit float {i.e. (2−2^-23) × 2^27 ≈ 3.4 × 10^38}
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:float">
+      <xsd:minExclusive value="0.0"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="PercentFraction">
+    <xsd:annotation>
+      <xsd:documentation>
+        A simple type that restricts the value to a float between 0 and 1 (inclusive).
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:float">
+      <xsd:maxInclusive value="1.0"/>
+      <xsd:minInclusive value="0.0"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="UniversallyUniqueIdentifier">
+    <xsd:annotation>
+      <xsd:documentation>
+        This is a unique ID for the file but does not conform to the ID pattern used in the rest of the file.
+        The rest of the IDs are either an full LSID or an internal ID which is a string that is simply unique in this file.
+        As the UniversallyUniqueIdentifier is used from outside this file to identify it having the same ID in another file could cause problems.
+        A UUID is 32 hexadecimal digits, in 5 groups, 8-4-4-4-12, separated by hyphens
+        e.g. urn:uuid:3e450fae-b8f2-4d35-aa54-702168b2487f
+        There are methods to generate these in most modern languages.
+        http://www.ietf.org/rfc/rfc4122.txt
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:anyURI">
+      <xsd:pattern value="(urn:uuid:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:complexType name="Map">
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>Maps</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        This is a Mapping of key/value pairs.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence minOccurs="1" maxOccurs="1">
+      <xsd:element name="M" minOccurs="0" maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:appinfo><xsdfu xmlns=""><plural>Ms</plural></xsdfu></xsd:appinfo>
+          <xsd:documentation> This is a key/value pair used to build up a Mapping. The
+          Element and Attribute name are kept to single letters to minimize the
+          length at the expense of readability as they are likely to occur many
+          times. </xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+          <xsd:simpleContent>
+            <xsd:extension base="xsd:string">
+              <xsd:attribute name="K" type="xsd:string"/>
+            </xsd:extension>
+          </xsd:simpleContent>
+        </xsd:complexType>
+      </xsd:element>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:simpleType name="Binning">
+    <xsd:annotation>
+      <xsd:documentation>
+        Represents the number of pixels that are combined to form larger pixels. {used:CCD,EMCCD}
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="1x1">
+        <xsd:annotation>
+          <xsd:documentation>No binning.</xsd:documentation>
+          <xsd:appinfo><xsdfu xmlns="">
+            <enum name="1×1" enum="ONEBYONE" compatregex="^\\s*1.*x.*1\\s*"/>
+          </xsdfu></xsd:appinfo>
+        </xsd:annotation>
+      </xsd:enumeration>
+      <xsd:enumeration value="2x2">
+        <xsd:annotation>
+          <xsd:documentation>2×2 binning.</xsd:documentation>
+          <xsd:appinfo><xsdfu xmlns="">
+            <enum name="2×2" enum="TWOBYTWO" compatregex="^\\s*2.*x.*2\\s*"/>
+          </xsdfu></xsd:appinfo>
+        </xsd:annotation>
+      </xsd:enumeration>
+      <xsd:enumeration value="4x4">
+        <xsd:annotation>
+          <xsd:documentation>4×4 binning.</xsd:documentation>
+          <xsd:appinfo><xsdfu xmlns="">
+            <enum name="4×4" enum="FOURBYFOUR" compatregex="^\\s*4.*x.*4\\s*"/>
+          </xsdfu></xsd:appinfo>
+        </xsd:annotation>
+      </xsd:enumeration>
+      <xsd:enumeration value="8x8">
+        <xsd:annotation>
+          <xsd:documentation>8×8 binning.</xsd:documentation>
+          <xsd:appinfo><xsdfu xmlns="">
+            <enum name="8×8" enum="EIGHTBYEIGHT" compatregex="^\\s*8.*x.*8\\s*"/>
+          </xsdfu></xsd:appinfo>
+        </xsd:annotation>
+      </xsd:enumeration>
+      <xsd:enumeration value="Other">
+        <xsd:annotation>
+          <xsd:documentation>Other binning value.</xsd:documentation>
+          <xsd:appinfo><xsdfu xmlns="">
+            <enum enum="OTHER"/>
+          </xsdfu></xsd:appinfo>
+        </xsd:annotation>
+      </xsd:enumeration>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="FontFamily">
+    <xsd:annotation>
+      <xsd:documentation>
+        The font family used to draw the text. [enumeration]
+        Note: these values are all lower case so they match
+        the standard HTML/CSS values. "fantasy" has been
+        included for completeness we do not recommended its
+        regular use.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="serif">
+        <xsd:annotation>
+          <xsd:documentation>serif.</xsd:documentation>
+          <xsd:appinfo><xsdfu xmlns="">
+            <enum enum="SERIF"/>
+          </xsdfu></xsd:appinfo>
+        </xsd:annotation>
+      </xsd:enumeration>
+      <xsd:enumeration value="sans-serif">
+        <xsd:annotation>
+          <xsd:documentation>sans-serif.</xsd:documentation>
+          <xsd:appinfo><xsdfu xmlns="">
+            <enum enum="SANSSERIF"/>
+          </xsdfu></xsd:appinfo>
+        </xsd:annotation>
+      </xsd:enumeration>
+      <xsd:enumeration value="cursive">
+        <xsd:annotation>
+          <xsd:documentation>cursive.</xsd:documentation>
+          <xsd:appinfo><xsdfu xmlns="">
+            <enum enum="CURSIVE"/>
+          </xsdfu></xsd:appinfo>
+        </xsd:annotation>
+      </xsd:enumeration>
+      <xsd:enumeration value="fantasy">
+        <xsd:annotation>
+          <xsd:documentation>fantasy.</xsd:documentation>
+          <xsd:appinfo><xsdfu xmlns="">
+            <enum enum="FANTASY"/>
+          </xsdfu></xsd:appinfo>
+        </xsd:annotation>
+      </xsd:enumeration>
+      <xsd:enumeration value="monospace">
+        <xsd:annotation>
+          <xsd:documentation>monospace.</xsd:documentation>
+          <xsd:appinfo><xsdfu xmlns="">
+            <enum enum="MONOSPACE"/>
+          </xsdfu></xsd:appinfo>
+        </xsd:annotation>
+      </xsd:enumeration>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="PixelType">
+    <xsd:annotation>
+      <xsd:documentation>
+        The number size/kind used to represent a pixel
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value = "int8">
+        <xsd:annotation>
+          <xsd:documentation>8 bit signed integer.</xsd:documentation>
+          <xsd:appinfo><xsdfu xmlns=""><enum enum="INT8"/></xsdfu></xsd:appinfo>
+        </xsd:annotation>
+      </xsd:enumeration>
+      <xsd:enumeration value = "int16">
+        <xsd:annotation>
+          <xsd:documentation>16 bit signed integer.</xsd:documentation>
+          <xsd:appinfo><xsdfu xmlns=""><enum enum="INT16"/></xsdfu></xsd:appinfo>
+        </xsd:annotation>
+      </xsd:enumeration>
+      <xsd:enumeration value = "int32">
+        <xsd:annotation>
+          <xsd:documentation>32 bit signed integer.</xsd:documentation>
+          <xsd:appinfo><xsdfu xmlns=""><enum enum="INT32"/></xsdfu></xsd:appinfo>
+        </xsd:annotation>
+      </xsd:enumeration>
+      <xsd:enumeration value = "uint8">
+        <xsd:annotation>
+          <xsd:documentation>8 bit unsigned integer.</xsd:documentation>
+          <xsd:appinfo><xsdfu xmlns=""><enum enum="UINT8"/></xsdfu></xsd:appinfo>
+        </xsd:annotation>
+      </xsd:enumeration>
+      <xsd:enumeration value = "uint16">
+        <xsd:annotation>
+          <xsd:documentation>16 bit unsigned integer.</xsd:documentation>
+          <xsd:appinfo><xsdfu xmlns=""><enum enum="UINT16"/></xsdfu></xsd:appinfo>
+        </xsd:annotation>
+      </xsd:enumeration>
+      <xsd:enumeration value = "uint32">
+        <xsd:annotation>
+          <xsd:documentation>32 bit unsigned integer.</xsd:documentation>
+          <xsd:appinfo><xsdfu xmlns=""><enum enum="UINT32"/></xsdfu></xsd:appinfo>
+        </xsd:annotation>
+      </xsd:enumeration>
+      <xsd:enumeration value = "float">
+        <xsd:annotation>
+          <xsd:documentation>single-precision floating point.</xsd:documentation>
+          <xsd:appinfo><xsdfu xmlns=""><enum enum="FLOAT"/></xsdfu></xsd:appinfo>
+        </xsd:annotation>
+      </xsd:enumeration>
+      <xsd:enumeration value = "double">
+        <xsd:annotation>
+          <xsd:documentation>double-precision floating point.</xsd:documentation>
+          <xsd:appinfo><xsdfu xmlns=""><enum enum="DOUBLE"/></xsdfu></xsd:appinfo>
+        </xsd:annotation>
+      </xsd:enumeration>
+      <xsd:enumeration value = "complex">
+        <xsd:annotation>
+          <xsd:documentation>complex single-precision floating point.</xsd:documentation>
+          <xsd:appinfo><xsdfu xmlns=""><enum enum="COMPLEXFLOAT"/></xsdfu></xsd:appinfo>
+        </xsd:annotation>
+      </xsd:enumeration>
+      <xsd:enumeration value = "double-complex">
+        <xsd:annotation>
+          <xsd:documentation>complex double-precision floating point.</xsd:documentation>
+          <xsd:appinfo><xsdfu xmlns=""><enum enum="COMPLEXDOUBLE"/></xsdfu></xsd:appinfo>
+        </xsd:annotation>
+      </xsd:enumeration>
+      <xsd:enumeration value = "bit">
+        <xsd:annotation>
+          <xsd:documentation>bit mask.</xsd:documentation>
+          <xsd:appinfo><xsdfu xmlns=""><enum enum="BIT"/></xsdfu></xsd:appinfo>
+        </xsd:annotation>
+      </xsd:enumeration>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="Color">
+    <xsd:annotation>
+      <xsd:documentation>
+        A simple type that identifies itself as a Color, the value is an integer between -2,147,483,648 and 2,147,483,647 (inclusive).
+        The value is a signed 32 bit encoding of RGBA so "-1" is #FFFFFFFF or solid white.
+        NOTE: Prior to the 2012-06 schema the default values were incorrect and produced a transparent red not solid white.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:int">
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="UnitsLength">
+    <xsd:annotation>
+      <xsd:documentation>
+        The units used to represent a length
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value =  "Ym"><xsd:annotation><xsd:documentation>yottameter SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="yottameter" plural="yottameter" altname="yottametre" altplural="yottametres" unitsystem="SI.METER" enum="YOTTAMETER"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "Zm"><xsd:annotation><xsd:documentation>zettameter SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="zettameter" plural="zettameter" altname="zettametre" altplural="zettametres" unitsystem="SI.METER" enum="ZETTAMETER"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "Em"><xsd:annotation><xsd:documentation> exameter SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="exameter" plural="exameter" altname="exametre" altplural="exametres" unitsystem="SI.METER" enum="EXAMETER"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "Pm"><xsd:annotation><xsd:documentation>petameter SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="petameter" plural="petameter" altname="petametre" altplural="petametres" unitsystem="SI.METER" enum="PETAMETER"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "Tm"><xsd:annotation><xsd:documentation>terameter SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="terameter" plural="terameter" altname="terametre" altplural="terametres" unitsystem="SI.METER" enum="TERAMETER"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "Gm"><xsd:annotation><xsd:documentation>gigameter SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="gigameter" plural="gigameter" altname="gigametre" altplural="gigametres" unitsystem="SI.METER" enum="GIGAMETER"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "Mm"><xsd:annotation><xsd:documentation>megameter SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="megameter" plural="megameter" altname="megametre" altplural="megametres" unitsystem="SI.METER" enum="MEGAMETER"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "km"><xsd:annotation><xsd:documentation>kilometer SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="kilometer" plural="kilometer" altname="kilometre" altplural="kilometres" unitsystem="SI.METER" enum="KILOMETER"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "hm"><xsd:annotation><xsd:documentation>hectometer SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="hectometer" plural="hectometer" altname="hectometre" altplural="hectometres" unitsystem="SI.METER" enum="HECTOMETER"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value = "dam"><xsd:annotation><xsd:documentation>decameter SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="decameter" plural="decameter" altname="decametre" altplural="decametres" unitsystem="SI.METER" enum="DECAMETER"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =   "m"><xsd:annotation><xsd:documentation>meter SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="meter" plural="meter" altname="metre" altplural="metres" unitsystem="SI.METER" enum="METER"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "dm"><xsd:annotation><xsd:documentation>decimeter SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="decimeter" plural="decimeter" altname="decimetre" altplural="decimetres" unitsystem="SI.METER" enum="DECIMETER"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "cm"><xsd:annotation><xsd:documentation>centimeter SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="centimeter" plural="centimeter" altname="centimetre" altplural="centimetres" unitsystem="SI.METER" enum="CENTIMETER"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "mm"><xsd:annotation><xsd:documentation>millimeter SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="millimeter" plural="millimeter" altname="millimetre" altplural="millimetres" unitsystem="SI.METER" enum="MILLIMETER"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "µm"><xsd:annotation><xsd:documentation>micrometer SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="micrometer" plural="micrometer" altname="micrometre" altplural="micrometres" unitsystem="SI.METER" enum="MICROMETER"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "nm"><xsd:annotation><xsd:documentation>nanometer SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="nanometer" plural="nanometer" altname="nanometre" altplural="nanometres" unitsystem="SI.METER" enum="NANOMETER"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "pm"><xsd:annotation><xsd:documentation>picometer SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="picometer" plural="picometer" altname="picometre" altplural="picometres" unitsystem="SI.METER" enum="PICOMETER"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "fm"><xsd:annotation><xsd:documentation>femtometer SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="femtometer" plural="femtometer" altname="femtometre" altplural="femtometres" unitsystem="SI.METER" enum="FEMTOMETER"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "am"><xsd:annotation><xsd:documentation>attometer SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="attometer" plural="attometer" altname="attometre" altplural="attometres" unitsystem="SI.METER" enum="ATTOMETER"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "zm"><xsd:annotation><xsd:documentation>zeptometer SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="zeptometer" plural="zeptometer" altname="zeptometre" altplural="zeptometres" unitsystem="SI.METER" enum="ZEPTOMETER"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "ym"><xsd:annotation><xsd:documentation>yoctometer SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="yoctometer" plural="yoctometer" altname="yoctometre" altplural="yoctometres" unitsystem="SI.METER" enum="YOCTOMETER"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+
+      <xsd:enumeration value = "Å"><xsd:annotation><xsd:documentation>ångström SI-derived unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="ångström" plural="ångströms" unitsystem="SI.METER" enum="ANGSTROM"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+
+      <xsd:enumeration value = "thou"><xsd:annotation><xsd:documentation>thou Imperial unit (or mil, 1/1000 inch).</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="thou" plural="thous" unitsystem="Imperial" enum="THOU"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value = "li"><xsd:annotation><xsd:documentation>line Imperial unit (1/12 inch).</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="line" plural="lines" unitsystem="Imperial" enum="LINE"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value = "in"><xsd:annotation><xsd:documentation>inch Imperial unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="inch" plural="inches" unitsystem="Imperial" enum="INCH"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value = "ft"><xsd:annotation><xsd:documentation>foot Imperial unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="foot" plural="feet" unitsystem="Imperial" enum="FOOT"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value = "yd"><xsd:annotation><xsd:documentation>yard Imperial unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="yard" plural="yards" unitsystem="Imperial" enum="YARD"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value = "mi"><xsd:annotation><xsd:documentation>terrestrial mile Imperial unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="mile" plural="miles" unitsystem="Imperial" enum="MILE"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+
+      <xsd:enumeration value = "ua"><xsd:annotation><xsd:documentation>astronomical unit SI-derived unit. The official term is ua as the SI standard assigned AU to absorbance unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="astronomical unit" plural="astronomical units" unitsystem="SI.METER" enum="ASTRONOMICALUNIT"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value = "ly"><xsd:annotation><xsd:documentation>light year.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="light year" plural="light years" unitsystem="SI.METER" enum="LIGHTYEAR"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value = "pc"><xsd:annotation><xsd:documentation>parsec.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="parsec" plural="parsecs" unitsystem="SI.METER" enum="PARSEC"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+
+      <xsd:enumeration value = "pt"><xsd:annotation><xsd:documentation>typography point Imperial-derived unit (1/72 inch). Use of this unit should be limited to font sizes.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="point" plural="points" unitsystem="Imperial" enum="POINT"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value = "pixel"><xsd:annotation><xsd:documentation>pixel abstract unit.  This is not convertible to any other length unit without a calibrated scaling factor. Its use should should be limited to ROI objects, and converted to an appropriate length units using the PhysicalSize units of the Image the ROI is attached to.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="pixel" plural="pixels" unitsystem="Pixel" enum="PIXEL"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+
+      <xsd:enumeration value = "reference frame"><xsd:annotation><xsd:documentation>reference frame abstract unit.  This is not convertible to any other length unit without a scaling factor.  Its use should be limited to uncalibrated stage positions, and converted to an appropriate length unit using a calibrated scaling factor.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="reference frame" unitsystem="ReferenceFrame" enum="REFERENCEFRAME"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="UnitsTime">
+    <xsd:annotation>
+      <xsd:documentation>
+        The units used to represent a time interval
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value =  "Ys"><xsd:annotation><xsd:documentation>yottasecond SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="yottasecond" plural="yottaseconds" unitsystem="SI.SECOND" enum="YOTTASECOND"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "Zs"><xsd:annotation><xsd:documentation>zettasecond SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="zettasecond" plural="zettaseconds" unitsystem="SI.SECOND" enum="ZETTASECOND"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "Es"><xsd:annotation><xsd:documentation>exasecond SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="exasecond" plural="exaseconds" unitsystem="SI.SECOND" enum="EXASECOND"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "Ps"><xsd:annotation><xsd:documentation>petasecond SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="petasecond" plural="petaseconds" unitsystem="SI.SECOND" enum="PETASECOND"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "Ts"><xsd:annotation><xsd:documentation>terasecond SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="terasecond" plural="teraseconds" unitsystem="SI.SECOND" enum="TERASECOND"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "Gs"><xsd:annotation><xsd:documentation>gigasecond SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="gigasecond" plural="gigaseconds" unitsystem="SI.SECOND" enum="GIGASECOND"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "Ms"><xsd:annotation><xsd:documentation>megasecond SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="megasecond" plural="megaseconds" unitsystem="SI.SECOND" enum="MEGASECOND"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "ks"><xsd:annotation><xsd:documentation>kilosecond SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="kilosecond" plural="kiloseconds" unitsystem="SI.SECOND" enum="KILOSECOND"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "hs"><xsd:annotation><xsd:documentation>hectosecond SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="hectosecond" plural="hectoseconds" unitsystem="SI.SECOND" enum="HECTOSECOND"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value = "das"><xsd:annotation><xsd:documentation>decasecond SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="decasecond" plural="decaseconds" unitsystem="SI.SECOND" enum="DECASECOND"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =   "s"><xsd:annotation><xsd:documentation>second SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="second" plural="seconds" unitsystem="SI.SECOND" enum="SECOND"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "ds"><xsd:annotation><xsd:documentation>decisecond SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="decisecond" plural="deciseconds" unitsystem="SI.SECOND" enum="DECISECOND"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "cs"><xsd:annotation><xsd:documentation>centisecond SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="centisecond" plural="centiseconds" unitsystem="SI.SECOND" enum="CENTISECOND"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "ms"><xsd:annotation><xsd:documentation>millisecond SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="millisecond" plural="milliseconds" unitsystem="SI.SECOND" enum="MILLISECOND"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "µs"><xsd:annotation><xsd:documentation>microsecond SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="microsecond" plural="microseconds" unitsystem="SI.SECOND" enum="MICROSECOND"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "ns"><xsd:annotation><xsd:documentation>nanosecond SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="nanosecond" plural="nanoseconds" unitsystem="SI.SECOND" enum="NANOSECOND"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "ps"><xsd:annotation><xsd:documentation>picosecond SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="picosecond" plural="picoseconds" unitsystem="SI.SECOND" enum="PICOSECOND"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "fs"><xsd:annotation><xsd:documentation>femtosecond SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="femtosecond" plural="femtoseconds" unitsystem="SI.SECOND" enum="FEMTOSECOND"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "as"><xsd:annotation><xsd:documentation>attosecond SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="attosecond" plural="attoseconds" unitsystem="SI.SECOND" enum="ATTOSECOND"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "zs"><xsd:annotation><xsd:documentation>zeptosecond SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="zeptosecond" plural="zeptoseconds" unitsystem="SI.SECOND" enum="ZEPTOSECOND"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "ys"><xsd:annotation><xsd:documentation>yoctosecond SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="yoctosecond" plural="yoctoseconds" unitsystem="SI.SECOND" enum="YOCTOSECOND"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+
+      <xsd:enumeration value = "min"><xsd:annotation><xsd:documentation>minute SI-derived unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="minute" plural="minutes" unitsystem="SI.SECOND" enum="MINUTE"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =   "h"><xsd:annotation><xsd:documentation>hour SI-derived unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="hour" plural="hours" unitsystem="SI.SECOND" enum="HOUR"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =   "d"><xsd:annotation><xsd:documentation>day SI-derived unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="day" plural="days" unitsystem="SI.SECOND" enum="DAY"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="UnitsPressure">
+    <xsd:annotation>
+      <xsd:documentation>
+        The units used to represent a pressure
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value =  "YPa"><xsd:annotation><xsd:documentation>yottapascal SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="yottapascal" plural="yottapascals" unitsystem="SI.PASCAL" enum="YOTTAPASCAL"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "ZPa"><xsd:annotation><xsd:documentation>zettapascal SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="zettapascal" plural="zettapascals" unitsystem="SI.PASCAL" enum="ZETTAPASCAL"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "EPa"><xsd:annotation><xsd:documentation>exapascal SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="exapascal" plural="exapascals" unitsystem="SI.PASCAL" enum="EXAPASCAL"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "PPa"><xsd:annotation><xsd:documentation>petapascal SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="petapascal" plural="petapascals" unitsystem="SI.PASCAL" enum="PETAPASCAL"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "TPa"><xsd:annotation><xsd:documentation>terapascal SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="terapascal" plural="terapascals" unitsystem="SI.PASCAL" enum="TERAPASCAL"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "GPa"><xsd:annotation><xsd:documentation>gigapascal SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="gigapascal" plural="gigapascals" unitsystem="SI.PASCAL" enum="GIGAPASCAL"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "MPa"><xsd:annotation><xsd:documentation>megapascal SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="megapascal" plural="megapascals" unitsystem="SI.PASCAL" enum="MEGAPASCAL"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "kPa"><xsd:annotation><xsd:documentation>kilopascal SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="kilopascal" plural="kilopascals" unitsystem="SI.PASCAL" enum="KILOPASCAL"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "hPa"><xsd:annotation><xsd:documentation>hectopascal SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="hectopascal" plural="hectopascals" unitsystem="SI.PASCAL" enum="HECTOPASCAL"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value = "daPa"><xsd:annotation><xsd:documentation>decapascal SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="decapascal" plural="decapascals" unitsystem="SI.PASCAL" enum="DECAPASCAL"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =   "Pa"><xsd:annotation><xsd:documentation>pascal SI unit.  Note the C++ enum is mixed case due to PASCAL being a macro used by the Microsoft C and C++ compiler.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="pascal" plural="pascals" unitsystem="SI.PASCAL" enum="PASCAL" cppenum="Pascal"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "dPa"><xsd:annotation><xsd:documentation>decipascal SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="decipascal" plural="decipascals" unitsystem="SI.PASCAL" enum="DECIPASCAL"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "cPa"><xsd:annotation><xsd:documentation>centipascal SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="centipascal" plural="centipascals" unitsystem="SI.PASCAL" enum="CENTIPASCAL"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "mPa"><xsd:annotation><xsd:documentation>millipascal SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="millipascal" plural="millipascals" unitsystem="SI.PASCAL" enum="MILLIPASCAL"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "µPa"><xsd:annotation><xsd:documentation>micropascal SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="micropascal" plural="micropascals" unitsystem="SI.PASCAL" enum="MICROPASCAL"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "nPa"><xsd:annotation><xsd:documentation>nanopascal SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="nanopascal" plural="nanopascals" unitsystem="SI.PASCAL" enum="NANOPASCAL"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "pPa"><xsd:annotation><xsd:documentation>picopascal SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="picopascal" plural="picopascals" unitsystem="SI.PASCAL" enum="PICOPASCAL"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "fPa"><xsd:annotation><xsd:documentation>femtopascal SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="femtopascal" plural="femtopascals" unitsystem="SI.PASCAL" enum="FEMTOPASCAL"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "aPa"><xsd:annotation><xsd:documentation>attopascal SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="attopascal" plural="attopascals" unitsystem="SI.PASCAL" enum="ATTOPASCAL"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "zPa"><xsd:annotation><xsd:documentation>zeptopascal SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="zeptopascal" plural="zeptopascals" unitsystem="SI.PASCAL" enum="ZEPTOPASCAL"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "yPa"><xsd:annotation><xsd:documentation>yoctopascal SI unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="yoctopascal" plural="yoctopascals" unitsystem="SI.PASCAL" enum="YOCTOPASCAL"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =   "bar"><xsd:annotation><xsd:documentation>bar SI-derived unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="bar" plural="bars" unitsystem="SI.PASCAL" enum="BAR"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "Mbar"><xsd:annotation><xsd:documentation>megabar SI-derived unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="megabar" plural="megabars" unitsystem="SI.PASCAL" enum="MEGABAR"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "kbar"><xsd:annotation><xsd:documentation>kilobar SI-derived unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="kilobar" plural="kilobars" unitsystem="SI.PASCAL" enum="KILOBAR"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "dbar"><xsd:annotation><xsd:documentation>decibar SI-derived unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="decibar" plural="decibars" unitsystem="SI.PASCAL" enum="DECIBAR"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "cbar"><xsd:annotation><xsd:documentation>centibar SI-derived unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="centibar" plural="centibars" unitsystem="SI.PASCAL" enum="CENTIBAR"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "mbar"><xsd:annotation><xsd:documentation>millibar SI-derived unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="millibar" plural="millibars" unitsystem="SI.PASCAL" enum="MILLIBAR"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+
+      <xsd:enumeration value =  "atm"><xsd:annotation><xsd:documentation>standard atmosphere SI-derived unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="atmosphere" plural="atmospheres" unitsystem="SI.PASCAL" enum="ATMOSPHERE"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+
+      <xsd:enumeration value =  "psi"><xsd:annotation><xsd:documentation>pound-force per square inch Imperial unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="psi" unitsystem="SI.PASCAL" enum="PSI"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+
+      <xsd:enumeration value =  "Torr"><xsd:annotation><xsd:documentation>torr SI-derived unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="torr" plural="torrs" unitsystem="SI.PASCAL" enum="TORR"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value = "mTorr"><xsd:annotation><xsd:documentation>millitorr SI-derived unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="millitorr" plural="millitorrs" unitsystem="SI.PASCAL" enum="MILLITORR"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+
+      <xsd:enumeration value = "mm Hg"><xsd:annotation><xsd:documentation>millimetre of mercury SI-derived unit</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="mmhg" unitsystem="SI.PASCAL" enum="MMHG"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="UnitsAngle">
+    <xsd:annotation>
+      <xsd:documentation>
+        The units used to represent an angle
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value = "deg"><xsd:annotation><xsd:documentation>degree unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="degree" plural="degrees" unitsystem="SI.RADIAN" enum="DEGREE"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value = "rad"><xsd:annotation><xsd:documentation>radian unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="radian" plural="radians" unitsystem="SI.RADIAN" enum="RADIAN"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value = "gon"><xsd:annotation><xsd:documentation>gradian unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="gradian" plural="gradians" unitsystem="SI.RADIAN" enum="GRADIAN"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="UnitsTemperature">
+    <xsd:annotation>
+      <xsd:documentation>
+        The units used to represent a temperature
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value =   "°C"><xsd:annotation><xsd:documentation>degree Celsius unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="celsius" unitsystem="SI.KELVIN" enum="CELSIUS"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =   "°F"><xsd:annotation><xsd:documentation>degree Fahrenheit unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="fahrenheit" unitsystem="SI.KELVIN" enum="FAHRENHEIT"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =    "K"><xsd:annotation><xsd:documentation>Kelvin unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="kelvin" plural="kelvins" unitsystem="SI.KELVIN" enum="KELVIN"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =   "°R"><xsd:annotation><xsd:documentation>degree Rankine unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="rankine" unitsystem="SI.KELVIN" enum="RANKINE"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="UnitsElectricPotential">
+    <xsd:annotation>
+      <xsd:documentation>
+        The units used to represent an electric potential
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value =  "YV"><xsd:annotation><xsd:documentation>yottavolt unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="yottavolt" plural="yottavolts" unitsystem="SI.VOLT" enum="YOTTAVOLT"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "ZV"><xsd:annotation><xsd:documentation>zettavolt unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="zettavolt" plural="zettavolts" unitsystem="SI.VOLT" enum="ZETTAVOLT"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "EV"><xsd:annotation><xsd:documentation>exavolt unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="exavolt" plural="exavolts" unitsystem="SI.VOLT" enum="EXAVOLT"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "PV"><xsd:annotation><xsd:documentation>petavolt unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="petavolt" plural="petavolts" unitsystem="SI.VOLT" enum="PETAVOLT"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "TV"><xsd:annotation><xsd:documentation>teravolt unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="teravolt" plural="teravolts" unitsystem="SI.VOLT" enum="TERAVOLT"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "GV"><xsd:annotation><xsd:documentation>gigavolt unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="gigavolt" plural="gigavolts" unitsystem="SI.VOLT" enum="GIGAVOLT"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "MV"><xsd:annotation><xsd:documentation>megavolt unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="megavolt" plural="megavolts" unitsystem="SI.VOLT" enum="MEGAVOLT"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "kV"><xsd:annotation><xsd:documentation>kilovolt unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="kilovolt" plural="kilovolts" unitsystem="SI.VOLT" enum="KILOVOLT"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "hV"><xsd:annotation><xsd:documentation>hectovolt unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="hectovolt" plural="hectovolts" unitsystem="SI.VOLT" enum="HECTOVOLT"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value = "daV"><xsd:annotation><xsd:documentation>decavolt unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="decavolt" plural="decavolts" unitsystem="SI.VOLT" enum="DECAVOLT"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =   "V"><xsd:annotation><xsd:documentation>volt unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="volt" plural="volts" unitsystem="SI.VOLT" enum="VOLT"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "dV"><xsd:annotation><xsd:documentation>decivolt unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="decivolt" plural="decivolts" unitsystem="SI.VOLT" enum="DECIVOLT"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "cV"><xsd:annotation><xsd:documentation>centivolt unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="centivolt" plural="centivolts" unitsystem="SI.VOLT" enum="CENTIVOLT"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "mV"><xsd:annotation><xsd:documentation>millivolt unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="millivolt" plural="millivolts" unitsystem="SI.VOLT" enum="MILLIVOLT"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "µV"><xsd:annotation><xsd:documentation>microvolt unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="microvolt" plural="microvolts" unitsystem="SI.VOLT" enum="MICROVOLT"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "nV"><xsd:annotation><xsd:documentation>nanovolt unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="nanovolt" plural="nanovolts" unitsystem="SI.VOLT" enum="NANOVOLT"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "pV"><xsd:annotation><xsd:documentation>picovolt unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="picovolt" plural="picovolts" unitsystem="SI.VOLT" enum="PICOVOLT"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "fV"><xsd:annotation><xsd:documentation>femtovolt unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="femtovolt" plural="femtovolts" unitsystem="SI.VOLT" enum="FEMTOVOLT"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "aV"><xsd:annotation><xsd:documentation>attovolt unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="attovolt" plural="attovolts" unitsystem="SI.VOLT" enum="ATTOVOLT"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "zV"><xsd:annotation><xsd:documentation>zeptovolt unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="zeptovolt" plural="zeptovolts" unitsystem="SI.VOLT" enum="ZEPTOVOLT"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "yV"><xsd:annotation><xsd:documentation>yoctovolt unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="yoctovolt" plural="yoctovolts" unitsystem="SI.VOLT" enum="YOCTOVOLT"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="UnitsPower">
+    <xsd:annotation>
+      <xsd:documentation>
+        The units used to represent power
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value =  "YW"><xsd:annotation><xsd:documentation>yottawatt unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="yottawatt" plural="yottawatts" unitsystem="SI.WATT" enum="YOTTAWATT"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "ZW"><xsd:annotation><xsd:documentation>zettawatt unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="zettawatt" plural="zettawatts" unitsystem="SI.WATT" enum="ZETTAWATT"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "EW"><xsd:annotation><xsd:documentation>exawatt unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="exawatt" plural="exawatts" unitsystem="SI.WATT" enum="EXAWATT"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "PW"><xsd:annotation><xsd:documentation>petawatt unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="petawatt" plural="petawatts" unitsystem="SI.WATT" enum="PETAWATT"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "TW"><xsd:annotation><xsd:documentation>terawatt unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="terawatt" plural="terawatts" unitsystem="SI.WATT" enum="TERAWATT"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "GW"><xsd:annotation><xsd:documentation>gigawatt unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="gigawatt" plural="gigawatts" unitsystem="SI.WATT" enum="GIGAWATT"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "MW"><xsd:annotation><xsd:documentation>megawatt unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="megawatt" plural="megawatts" unitsystem="SI.WATT" enum="MEGAWATT"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "kW"><xsd:annotation><xsd:documentation>kilowatt unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="kilowatt" plural="kilowatts" unitsystem="SI.WATT" enum="KILOWATT"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "hW"><xsd:annotation><xsd:documentation>hectowatt unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="hectowatt" plural="hectowatts" unitsystem="SI.WATT" enum="HECTOWATT"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value = "daW"><xsd:annotation><xsd:documentation>decawatt unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="decawatt" plural="decawatts" unitsystem="SI.WATT" enum="DECAWATT"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =   "W"><xsd:annotation><xsd:documentation>watt unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="watt" plural="watts" unitsystem="SI.WATT" enum="WATT"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "dW"><xsd:annotation><xsd:documentation>deciwatt unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="deciwatt" plural="deciwatts" unitsystem="SI.WATT" enum="DECIWATT"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "cW"><xsd:annotation><xsd:documentation>centiwatt unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="centiwatt" plural="centiwatts" unitsystem="SI.WATT" enum="CENTIWATT"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "mW"><xsd:annotation><xsd:documentation>milliwatt unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="milliwatt" plural="milliwatts" unitsystem="SI.WATT" enum="MILLIWATT"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "µW"><xsd:annotation><xsd:documentation>microwatt unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="microwatt" plural="microwatts" unitsystem="SI.WATT" enum="MICROWATT"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "nW"><xsd:annotation><xsd:documentation>nanowatt unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="nanowatt" plural="nanowatts" unitsystem="SI.WATT" enum="NANOWATT"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "pW"><xsd:annotation><xsd:documentation>picowatt unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="picowatt" plural="picowatts" unitsystem="SI.WATT" enum="PICOWATT"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "fW"><xsd:annotation><xsd:documentation>femtowatt unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="femtowatt" plural="femtowatts" unitsystem="SI.WATT" enum="FEMTOWATT"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "aW"><xsd:annotation><xsd:documentation>attowatt unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="attowatt" plural="attowatts" unitsystem="SI.WATT" enum="ATTOWATT"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "zW"><xsd:annotation><xsd:documentation>zeptowatt unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="zeptowatt" plural="zeptowatts" unitsystem="SI.WATT" enum="ZEPTOWATT"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "yW"><xsd:annotation><xsd:documentation>yoctowatt unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="yoctowatt" plural="yoctowatts" unitsystem="SI.WATT" enum="YOCTOWATT"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="UnitsFrequency">
+    <xsd:annotation>
+      <xsd:documentation>
+        The units used to represent frequency
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value =  "YHz"><xsd:annotation><xsd:documentation>yottahertz unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="yottahertz" unitsystem="SI.HERTZ" enum="YOTTAHERTZ"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "ZHz"><xsd:annotation><xsd:documentation>zettahertz unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="zettahertz" unitsystem="SI.HERTZ" enum="ZETTAHERTZ"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "EHz"><xsd:annotation><xsd:documentation>exahertz unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="exahertz" unitsystem="SI.HERTZ" enum="EXAHERTZ"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "PHz"><xsd:annotation><xsd:documentation>petahertz unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="petahertz" unitsystem="SI.HERTZ" enum="PETAHERTZ"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "THz"><xsd:annotation><xsd:documentation>terahertz unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="terahertz" unitsystem="SI.HERTZ" enum="TERAHERTZ"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "GHz"><xsd:annotation><xsd:documentation>gigahertz unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="gigahertz" unitsystem="SI.HERTZ" enum="GIGAHERTZ"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "MHz"><xsd:annotation><xsd:documentation>megahertz unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="megahertz" unitsystem="SI.HERTZ" enum="MEGAHERTZ"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "kHz"><xsd:annotation><xsd:documentation>kilohertz unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="kilohertz" unitsystem="SI.HERTZ" enum="KILOHERTZ"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "hHz"><xsd:annotation><xsd:documentation>hectohertz unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="hectohertz" unitsystem="SI.HERTZ" enum="HECTOHERTZ"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value = "daHz"><xsd:annotation><xsd:documentation>decahertz unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="decahertz" unitsystem="SI.HERTZ" enum="DECAHERTZ"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =   "Hz"><xsd:annotation><xsd:documentation>hertz unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="hertz" unitsystem="SI.HERTZ" enum="HERTZ"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "dHz"><xsd:annotation><xsd:documentation>decihertz unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="decihertz" unitsystem="SI.HERTZ" enum="DECIHERTZ"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "cHz"><xsd:annotation><xsd:documentation>centihertz unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="centihertz" unitsystem="SI.HERTZ" enum="CENTIHERTZ"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "mHz"><xsd:annotation><xsd:documentation>millihertz unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="millihertz" unitsystem="SI.HERTZ" enum="MILLIHERTZ"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "µHz"><xsd:annotation><xsd:documentation>microhertz unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="microhertz" unitsystem="SI.HERTZ" enum="MICROHERTZ"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "nHz"><xsd:annotation><xsd:documentation>nanohertz unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="nanohertz" unitsystem="SI.HERTZ" enum="NANOHERTZ"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "pHz"><xsd:annotation><xsd:documentation>picohertz unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="picohertz" unitsystem="SI.HERTZ" enum="PICOHERTZ"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "fHz"><xsd:annotation><xsd:documentation>femtohertz unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="femtohertz" unitsystem="SI.HERTZ" enum="FEMTOHERTZ"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "aHz"><xsd:annotation><xsd:documentation>attohertz unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="attohertz" unitsystem="SI.HERTZ" enum="ATTOHERTZ"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "zHz"><xsd:annotation><xsd:documentation>zeptohertz unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="zeptohertz" unitsystem="SI.HERTZ" enum="ZEPTOHERTZ"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+      <xsd:enumeration value =  "yHz"><xsd:annotation><xsd:documentation>yoctohertz unit.</xsd:documentation><xsd:appinfo><xsdfu xmlns=""><enum name="yoctohertz" unitsystem="SI.HERTZ" enum="YOCTOHERTZ"/></xsdfu></xsd:appinfo></xsd:annotation></xsd:enumeration>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <!-- Objective elements -->
+  <xsd:element name="Objective"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>Objectives</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        A description of the microscope's objective lens.
+        Required elements include the lens numerical aperture,
+        and the magnification, both of which a floating
+        point (real) numbers.
+        The values are those that are fixed for a particular
+        objective: either because it has been manufactured to
+        this specification or the value has been measured on
+        this particular objective.
+        Correction: This is the type of correction coating applied to this lens.
+        Immersion: This is the types of immersion medium the lens is designed to
+        work with. It is not the same as 'Medium' in ObjectiveRef (a
+        single type) as here Immersion can have compound values like 'Multi'.
+        LensNA: The numerical aperture of the lens (as a float)
+        NominalMagnification: The specified magnification e.g. x10
+        CalibratedMagnification: The measured magnification e.g. x10.3
+        WorkingDistance: WorkingDistance of the lens.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="ManufacturerSpec">
+          <xsd:sequence>
+            <xsd:element ref="AnnotationRef" minOccurs="0" maxOccurs="unbounded">
+              <xsd:annotation>
+                <xsd:appinfo><xsdfu xmlns=""><manytomany/></xsdfu></xsd:appinfo>
+              </xsd:annotation>
+            </xsd:element>
+          </xsd:sequence>
+          <xsd:attribute name="ID" use="required" type="ObjectiveID"/>
+          <xsd:attribute name="Correction" use="optional">
+            <xsd:annotation>
+              <xsd:documentation>The correction applied to the lens</xsd:documentation>
+            </xsd:annotation>
+            <xsd:simpleType>
+              <xsd:restriction base="xsd:string">
+                <xsd:enumeration value="UV"/>
+                <xsd:enumeration value="PlanApo"/>
+                <xsd:enumeration value="PlanFluor"/>
+                <xsd:enumeration value="SuperFluor"/>
+                <xsd:enumeration value="VioletCorrected"/>
+                <xsd:enumeration value="Achro"/>
+                <xsd:enumeration value="Achromat"/>
+                <xsd:enumeration value="Fluor"/>
+                <xsd:enumeration value="Fl"/>
+                <xsd:enumeration value="Fluar"/>
+                <xsd:enumeration value="Neofluar"/>
+                <xsd:enumeration value="Fluotar"/>
+                <xsd:enumeration value="Apo"/>
+                <xsd:enumeration value="PlanNeofluar"/>
+                <xsd:enumeration value="Other"/>
+              </xsd:restriction>
+            </xsd:simpleType>
+          </xsd:attribute>
+          <xsd:attribute name="Immersion" use="optional">
+            <xsd:annotation>
+              <xsd:documentation>The immersion medium the lens is designed for</xsd:documentation>
+            </xsd:annotation>
+            <xsd:simpleType>
+              <xsd:restriction base="xsd:string">
+                <xsd:enumeration value="Oil"/>
+                <xsd:enumeration value="Water"/>
+                <xsd:enumeration value="WaterDipping"/>
+                <xsd:enumeration value="Air"/>
+                <xsd:enumeration value="Multi"/>
+                <xsd:enumeration value="Glycerol"/>
+                <xsd:enumeration value="Other"/>
+              </xsd:restriction>
+            </xsd:simpleType>
+          </xsd:attribute>
+          <xsd:attribute name="LensNA" use="optional" type="xsd:float">
+            <xsd:annotation>
+              <xsd:documentation>
+                The numerical aperture of the lens expressed as a floating point (real) number.
+                Expected range 0.02 - 1.5 [units:none]
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="NominalMagnification" use="optional" type="xsd:float">
+            <xsd:annotation>
+              <xsd:documentation>
+                The magnification of the lens as specified by the manufacturer - i.e. '60' is a 60X lens. [units:none]
+                Note: The type of this has been changed from int to float to allow
+                the specification of additional lenses e.g. 0.5X lens
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="CalibratedMagnification" use="optional"  type="xsd:float">
+            <xsd:annotation>
+              <xsd:documentation>
+                The magnification of the lens as measured by a calibration process- i.e. '59.987' for a 60X lens. [units:none]
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="WorkingDistance" use="optional" type="xsd:float">
+            <xsd:annotation>
+              <xsd:documentation>
+                The working distance of the lens expressed as a floating point (real) number. Units are set by WorkingDistanceUnit.
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="WorkingDistanceUnit" use="optional" default="µm" type="UnitsLength">
+            <xsd:annotation>
+              <xsd:documentation>The units of the working distance - default:microns[µm].</xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="Iris" use="optional" type="xsd:boolean">
+            <xsd:annotation>
+              <xsd:documentation>
+                Records whether or not the objective was fitted with an Iris. [flag]
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="Detector"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>Detectors</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        The type of detector used to capture the image.
+        The Detector ID can be used as a reference within the Channel element in the Image element.
+        The values stored in Detector represent the fixed values,
+        variable values modified during the acquisition go in DetectorSettings
+
+        Each attribute now has an indication of what type of detector
+        it applies to. This is preparatory work for cleaning up and
+        possibly splitting this object into sub-types.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="ManufacturerSpec">
+          <xsd:sequence>
+            <xsd:element ref="AnnotationRef" minOccurs="0" maxOccurs="unbounded">
+              <xsd:annotation>
+                <xsd:appinfo><xsdfu xmlns=""><manytomany/></xsdfu></xsd:appinfo>
+              </xsd:annotation>
+            </xsd:element>
+          </xsd:sequence>
+          <xsd:attribute name="Gain" use="optional" type="xsd:float">
+            <xsd:annotation>
+              <xsd:documentation>
+                The Detector Gain for this detector, as a float. [units:none] {used:CCD,EMCCD,PMT}
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="Voltage" use="optional" type="xsd:float">
+            <xsd:annotation>
+              <xsd:documentation>
+                The Voltage of the detector (e.g. PMT voltage) as a float. {used:PMT}
+                Units are set by VoltageUnit.
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="VoltageUnit" use="optional" default="V" type="UnitsElectricPotential">
+            <xsd:annotation>
+              <xsd:documentation>The units of the Voltage - default:volts[V].</xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="Offset" use="optional" type="xsd:float">
+            <xsd:annotation>
+              <xsd:documentation>
+                The Detector Offset. [units:none] {used:CCD,EMCCD}
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="Zoom" use="optional" type="xsd:float">
+            <xsd:annotation>
+              <xsd:documentation>
+                The fixed Zoom for a detector. [units:none] {used:PMT}
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="AmplificationGain" use="optional" type="xsd:float">
+            <xsd:annotation>
+              <xsd:documentation>
+                Gain applied to the detector signal.
+                This is the electronic gain (as apposed to the inherent gain) that is set for the detector. [units:none] {used:EMCCD#EMGain}
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="ID" use="required" type="DetectorID"/>
+          <xsd:attribute name="Type" use="optional">
+            <xsd:annotation>
+              <xsd:documentation>
+                The Type of detector. E.g. CCD, PMT, EMCCD etc.
+              </xsd:documentation>
+            </xsd:annotation>
+            <xsd:simpleType>
+              <xsd:restriction base="xsd:string">
+                <xsd:enumeration value="CCD"/><!-- Charge-Coupled Device -->
+                <xsd:enumeration value="IntensifiedCCD"/>
+                <xsd:enumeration value="AnalogVideo"/>
+                <xsd:enumeration value="PMT"/><!-- Photomultiplier tube -->
+                <xsd:enumeration value="Photodiode"/>
+                <xsd:enumeration value="Spectroscopy"/>
+                <xsd:enumeration value="LifetimeImaging"/>
+                <xsd:enumeration value="CorrelationSpectroscopy"/>
+                <xsd:enumeration value="FTIR"/><!-- Fourier transform infrared spectroscopy -->
+                <xsd:enumeration value="EMCCD"/><!-- Electron Multiplying Charge Coupled Device -->
+                <xsd:enumeration value="APD"/><!-- Avalanche Photodiode -->
+                <xsd:enumeration value="CMOS"/><!-- complementary metal oxide semiconductor -->
+                <xsd:enumeration value="EBCCD"/><!-- electron-bombarded charge-coupled device -->
+                <xsd:enumeration value="Other"/>
+              </xsd:restriction>
+            </xsd:simpleType>
+          </xsd:attribute>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- Filter elements -->
+  <xsd:element name="FilterSet"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>FilterSets</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>Filter set manufacturer specification</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="ManufacturerSpec">
+          <xsd:sequence>
+            <xsd:element name="ExcitationFilterRef" type="FilterRef" minOccurs="0" maxOccurs="unbounded">
+              <xsd:annotation>
+                <xsd:appinfo><xsdfu xmlns=""><plural>ExcitationFilters</plural><manytomany/></xsdfu></xsd:appinfo>
+                <xsd:documentation>
+                  The Filters placed in the Excitation light path.
+                </xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element ref="DichroicRef" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="EmissionFilterRef" type="FilterRef" minOccurs="0" maxOccurs="unbounded">
+              <xsd:annotation>
+                <xsd:appinfo><xsdfu xmlns=""><plural>EmissionFilters</plural><manytomany/></xsdfu></xsd:appinfo>
+                <xsd:documentation>
+                  The Filters placed in the Emission light path.
+                </xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+          </xsd:sequence>
+          <xsd:attribute name="ID" use="required" type="FilterSetID"/>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="Filter"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>Filters</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        A filter is either an excitation or emission filters.
+        There should be one filter element specified per wavelength in the image.
+        The channel number associated with a filter set is specified in Channel.
+        It is based on the FilterSpec type, so has the required attributes Manufacturer, Model, and LotNumber.
+        It may also contain a Type attribute which may be set to
+        'LongPass', 'ShortPass', 'BandPass', 'MultiPass',
+        'Dichroic', 'NeutralDensity', 'Tuneable' or 'Other'.
+        It can be associated with an optional FilterWheel - Note: this is not the same as a FilterSet
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="ManufacturerSpec">
+          <xsd:sequence>
+            <xsd:element ref="TransmittanceRange" minOccurs="0" maxOccurs="1"/>
+            <xsd:element ref="AnnotationRef" minOccurs="0" maxOccurs="unbounded">
+              <xsd:annotation>
+                <xsd:appinfo><xsdfu xmlns=""><manytomany/></xsdfu></xsd:appinfo>
+              </xsd:annotation>
+            </xsd:element>
+          </xsd:sequence>
+          <xsd:attribute name="Type" use="optional">
+            <xsd:simpleType>
+              <xsd:restriction base="xsd:string">
+                <xsd:enumeration value="Dichroic"/>
+                <xsd:enumeration value="LongPass"/>
+                <xsd:enumeration value="ShortPass"/>
+                <xsd:enumeration value="BandPass"/>
+                <xsd:enumeration value="MultiPass"/>
+                <xsd:enumeration value="NeutralDensity"/>
+                <xsd:enumeration value="Tuneable"/>
+                <xsd:enumeration value="Other"/>
+              </xsd:restriction>
+            </xsd:simpleType>
+          </xsd:attribute>
+          <xsd:attribute name="FilterWheel" use="optional" type="xsd:string" >
+            <xsd:annotation>
+              <xsd:documentation>
+                A filter 'wheel' in OME can refer to any arrangement of filters in a filter holder of any shape. It could, for example, be a filter slider. [plain text string]
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="ID" use="required" type="FilterID"/>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="TransmittanceRange"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>TransmittanceRanges</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        This records the range of wavelengths that are transmitted by the filter. It also records the maximum amount of light transmitted.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:attribute name="CutIn" use="optional" type="PositiveFloat" >
+        <xsd:annotation>
+          <xsd:documentation>
+            CutIn is the wavelength below which there is less than 50% transmittance for a filter. Units are set by CutInUnit.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="CutInUnit" use="optional" default="nm" type="UnitsLength">
+        <xsd:annotation>
+          <xsd:documentation>The units of the CutIn - default:nanometres[nm].</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="CutOut" use="optional" type="PositiveFloat" >
+        <xsd:annotation>
+          <xsd:documentation>
+            CutOut is the wavelength above which there is less than 50% transmittance for a filter. Units are set by CutOutUnit.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="CutOutUnit" use="optional" default="nm" type="UnitsLength">
+        <xsd:annotation>
+          <xsd:documentation>The units of the CutOut - default:nanometres[nm].</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="CutInTolerance" use="optional" type="NonNegativeFloat" >
+        <xsd:annotation>
+          <xsd:documentation>
+            CutInTolerance. Units are set by CutInToleranceUnit.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="CutInToleranceUnit" use="optional" default="nm" type="UnitsLength">
+        <xsd:annotation>
+          <xsd:documentation>The units of the CutInTolerance - default:nanometres[nm].</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="CutOutTolerance" use="optional" type="NonNegativeFloat" >
+        <xsd:annotation>
+          <xsd:documentation>
+            CutOutTolerance. Units are set by CutOutToleranceUnit.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="CutOutToleranceUnit" use="optional" default="nm" type="UnitsLength">
+        <xsd:annotation>
+          <xsd:documentation>The units of the CutOutTolerance - default:nanometres[nm].</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="Transmittance" use="optional" type="PercentFraction" >
+        <xsd:annotation>
+          <xsd:documentation>
+            The amount of light the filter transmits at a maximum [units:none]
+            A fraction, as a value from 0.0 to 1.0.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="Dichroic"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>Dichroics</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>The dichromatic beamsplitter or dichroic mirror used for this filter combination.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="ManufacturerSpec">
+          <xsd:sequence>
+            <xsd:element ref="AnnotationRef" minOccurs="0" maxOccurs="unbounded">
+              <xsd:annotation>
+                <xsd:appinfo><xsdfu xmlns=""><manytomany/></xsdfu></xsd:appinfo>
+              </xsd:annotation>
+            </xsd:element>
+          </xsd:sequence>
+          <xsd:attribute name="ID" use="required" type="DichroicID"/>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="LightPath"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>LightPaths</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>A description of the light path</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element name="ExcitationFilterRef" type="FilterRef" minOccurs="0" maxOccurs="unbounded">
+          <xsd:annotation>
+            <xsd:appinfo><xsdfu xmlns=""><plural>ExcitationFilters</plural><parentordered/><manytomany/></xsdfu></xsd:appinfo>
+            <xsd:documentation>
+              The Filters placed in the Excitation light path.
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element ref="DichroicRef" minOccurs="0" maxOccurs="1"/>
+        <xsd:element name="EmissionFilterRef" type="FilterRef" minOccurs="0" maxOccurs="unbounded">
+          <xsd:annotation>
+            <xsd:appinfo><xsdfu xmlns=""><plural>EmissionFilters</plural><manytomany/></xsdfu></xsd:appinfo>
+            <xsd:documentation>
+              The Filters placed in the Emission light path.
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element ref="AnnotationRef" minOccurs="0" maxOccurs="unbounded">
+          <xsd:annotation>
+            <xsd:appinfo><xsdfu xmlns=""><manytomany/></xsdfu></xsd:appinfo>
+          </xsd:annotation>
+        </xsd:element>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="DichroicRef">  <!-- top level definition -->
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="Reference">
+          <xsd:attribute name="ID" use="required" type="DichroicID"/>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- Light elements -->
+  <xsd:element name="LightSourceGroup" abstract="true" type="LightSource"/> <!-- top level definition -->
+  <xsd:complexType name="LightSource">
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>LightSources</plural><abstract/></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        The lightsource for the instrument.  An instrument may have several light sources.
+        The type of lightsource is specified by one of the child-elements which are 'Laser', 'Filament', 'Arc' or 'LightEmittingDiode'.
+        Each of the light source types has its own Type attribute to further differentiate the light source
+        (eg, Nd-YAG for Laser or Hg for Arc).
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexContent>
+      <xsd:extension base="ManufacturerSpec">
+        <xsd:sequence>
+          <xsd:element ref="AnnotationRef" minOccurs="0" maxOccurs="unbounded">
+            <xsd:annotation>
+              <xsd:appinfo><xsdfu xmlns=""><manytomany/></xsdfu></xsd:appinfo>
+            </xsd:annotation>
+          </xsd:element>
+        </xsd:sequence>
+        <xsd:attribute name="ID" use="required" type="LightSourceID">
+          <xsd:annotation>
+            <xsd:documentation>
+              A LightSource ID must be specified for each light source, and the individual
+              light sources can be referred to by their LightSource IDs (eg from Channel).
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="Power" use="optional" type="xsd:float">
+          <xsd:annotation>
+            <xsd:documentation>
+              The light-source power. Units are set by PowerUnit.
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="PowerUnit" use="optional" default="mW" type="UnitsPower">
+          <xsd:annotation>
+            <xsd:documentation>The units of the Power - default:milliwatts[mW].</xsd:documentation>
+          </xsd:annotation>
+        </xsd:attribute>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:element name="Laser" substitutionGroup="LightSourceGroup"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>Lasers</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        Laser types are specified using two attributes - the Type and the LaserMedium.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="LightSource">
+          <xsd:sequence>
+            <xsd:element ref="Pump" minOccurs="0" maxOccurs="1">
+              <xsd:annotation>
+                <xsd:documentation>
+                  The Laser element may contain a Pump sub-element which refers to
+                  a LightSource used as a laser pump.
+                </xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+          </xsd:sequence>
+          <xsd:attribute name="Type" use="optional">
+            <xsd:annotation>
+              <xsd:documentation>
+                Type is the general category of laser.
+              </xsd:documentation>
+            </xsd:annotation>
+            <xsd:simpleType>
+              <xsd:restriction base="xsd:string">
+                <xsd:enumeration value="Excimer"/>
+                <xsd:enumeration value="Gas"/>
+                <xsd:enumeration value="MetalVapor"/>
+                <xsd:enumeration value="SolidState"/>
+                <xsd:enumeration value="Dye"/>
+                <xsd:enumeration value="Semiconductor"/>
+                <xsd:enumeration value="FreeElectron"/>
+                <xsd:enumeration value="Other"/>
+              </xsd:restriction>
+            </xsd:simpleType>
+          </xsd:attribute>
+          <xsd:attribute name="LaserMedium" use="optional">
+            <xsd:annotation>
+              <xsd:documentation>
+                The Medium attribute specifies the actual lasing medium
+                for a given laser type.
+              </xsd:documentation>
+            </xsd:annotation>
+            <xsd:simpleType>
+              <xsd:restriction base="xsd:string">
+                <!-- MetalVaporLaserMedia -->
+                <xsd:enumeration value="Cu"/>
+                <xsd:enumeration value="Ag"/>
+                <!-- ExcimerLaserMedia -->
+                <xsd:enumeration value="ArFl"/>
+                <xsd:enumeration value="ArCl"/>
+                <xsd:enumeration value="KrFl"/>
+                <xsd:enumeration value="KrCl"/>
+                <xsd:enumeration value="XeFl"/>
+                <xsd:enumeration value="XeCl"/>
+                <xsd:enumeration value="XeBr"/>
+                <!-- GasLaserMedia -->
+                <xsd:enumeration value="N"/>
+                <xsd:enumeration value="Ar"/>
+                <xsd:enumeration value="Kr"/>
+                <xsd:enumeration value="Xe"/>
+                <xsd:enumeration value="HeNe"/>
+                <xsd:enumeration value="HeCd"/>
+                <xsd:enumeration value="CO"/>
+                <xsd:enumeration value="CO2"/>
+                <xsd:enumeration value="H2O"/>
+                <xsd:enumeration value="HFl"/>
+                <!-- SolidStateLaserMedia -->
+                <xsd:enumeration value="NdGlass"/>
+                <xsd:enumeration value="NdYAG"/>
+                <xsd:enumeration value="ErGlass"/>
+                <xsd:enumeration value="ErYAG"/>
+                <xsd:enumeration value="HoYLF"/>
+                <xsd:enumeration value="HoYAG"/>
+                <xsd:enumeration value="Ruby"/>
+                <xsd:enumeration value="TiSapphire"/>
+                <xsd:enumeration value="Alexandrite"/>
+                <!-- DyeLaserMedia -->
+                <xsd:enumeration value="Rhodamine6G"/>
+                <xsd:enumeration value="CoumarinC30"/>
+                <!-- SemiconductorLaserMedia -->
+                <xsd:enumeration value="GaAs"/>
+                <xsd:enumeration value="GaAlAs"/>
+                <!-- FreeElectronLaserMedia -->
+                <xsd:enumeration value="EMinus"/>
+                <!-- OtherLaserMedia -->
+                <xsd:enumeration value="Other"/>
+              </xsd:restriction>
+            </xsd:simpleType>
+          </xsd:attribute>
+          <xsd:attribute name="Wavelength" use="optional" type="PositiveFloat">
+            <xsd:annotation>
+              <xsd:documentation>
+                The Wavelength of the laser. Units are set by WavelengthUnit.
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="WavelengthUnit" use="optional" default="nm" type="UnitsLength">
+            <xsd:annotation>
+              <xsd:documentation>The units of the Wavelength - default:nanometres[nm].</xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="FrequencyMultiplication" use="optional" type="PositiveInt">
+            <xsd:annotation>
+              <xsd:documentation>
+                FrequencyMultiplication that may be specified. [units:none]
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="Tuneable" use="optional" type="xsd:boolean">
+            <xsd:annotation>
+              <xsd:documentation>
+                Whether or not the laser is Tuneable [flag]
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="Pulse" use="optional">
+            <xsd:annotation>
+              <xsd:documentation>
+                The Pulse mode of the laser.
+              </xsd:documentation>
+            </xsd:annotation>
+            <xsd:simpleType>
+              <xsd:restriction base="xsd:string">
+                <xsd:enumeration value="CW"/>
+                <xsd:enumeration value="Single"/>
+                <xsd:enumeration value="QSwitched"/>
+                <xsd:enumeration value="Repetitive"/>
+                <xsd:enumeration value="ModeLocked"/>
+                <xsd:enumeration value="Other"/>
+              </xsd:restriction>
+            </xsd:simpleType>
+          </xsd:attribute>
+          <xsd:attribute name="PockelCell" use="optional" type="xsd:boolean">
+            <xsd:annotation>
+              <xsd:documentation>
+                If true the laser has a PockelCell to rotate the polarization of the beam. [flag]
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="RepetitionRate" use="optional" type="xsd:float">
+            <xsd:annotation>
+              <xsd:documentation>
+                The is the rate in Hz at which the laser pulses if
+                the Pulse type is 'Repetitive'. hertz[Hz]
+                Units are set by RepetitionRateUnit.
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="RepetitionRateUnit" use="optional" default="Hz" type="UnitsFrequency">
+            <xsd:annotation>
+              <xsd:documentation>The units of the RepetitionRate - default:hertz[Hz].</xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="Arc" substitutionGroup="LightSourceGroup"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>Arcs</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        The Arc element is used to describe various kinds of Arc lamps - Hg, Xe, HgXe.
+        The Power of the Arc is now stored in the LightSource.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="LightSource">
+          <xsd:attribute name="Type" use="optional">
+            <xsd:annotation>
+              <xsd:documentation>
+                The type of Arc lamp.
+              </xsd:documentation>
+            </xsd:annotation>
+            <xsd:simpleType>
+              <xsd:restriction base="xsd:string">
+                <xsd:enumeration value="Hg"/>
+                <xsd:enumeration value="Xe"/>
+                <xsd:enumeration value="HgXe"/>
+                <xsd:enumeration value="Other"/>
+              </xsd:restriction>
+            </xsd:simpleType>
+          </xsd:attribute>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="Filament" substitutionGroup="LightSourceGroup"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>Filaments</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        The Filament element is used to describe various kinds of filament bulbs such as Incadescent or Halogen.
+        The Power of the Filament is now stored in the LightSource.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="LightSource">
+          <xsd:attribute name="Type" use="optional">
+            <xsd:annotation>
+              <xsd:documentation>
+                The type of filament.
+              </xsd:documentation>
+            </xsd:annotation>
+            <xsd:simpleType>
+              <xsd:restriction base="xsd:string">
+                <xsd:enumeration value="Incandescent"/>
+                <xsd:enumeration value="Halogen"/>
+                <xsd:enumeration value="Other"/>
+              </xsd:restriction>
+            </xsd:simpleType>
+          </xsd:attribute>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="LightEmittingDiode" substitutionGroup="LightSourceGroup"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>LightEmittingDiodes</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        The LightEmittingDiode element is used to describe
+        various kinds of LED lamps.
+
+        As the LightEmittingDiode is inside a LightSource it already has
+        available the values from ManufacturerSpec
+        (Manufacturer, Model, SerialNumber, LotNumber)
+        And the values from LightSource which includes Power in milliwatts
+
+        We have looked at extending this element but have had a problem
+        producing a generic solution.
+
+        Possible attributes talked about adding include:
+        Power in lumens - but this is complicated by multi-channel
+        devices like CoolLED where each channel's power is different
+        Wavelength Range - not a simple value so would require
+        multiple attributes or a child element
+        Angle of Projection - this would be further affected by the
+        optics used for filtering the naked LED or that combine
+        power from multiple devices
+
+        These values are further affected if you over-drive the LED
+        resulting in a more complex system
+
+        Another issue is that LED's may not be used directly for
+        illumination but as drivers for secondary emissions from doped
+        fiber optics. This would require the fiber optics to be modeled.
+
+        Thanks to Paul Goodwin of Applied Precision of information about
+        this topic.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="LightSource"/>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="GenericExcitationSource" substitutionGroup="LightSourceGroup"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>GenericExcitationSources</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        The GenericExcitationSource element is used to represent
+        a source as a collection of key/value pairs, stored
+        in a Map. The other lightsource objects should
+        always be used in preference to this if possible.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="LightSource">
+          <xsd:sequence>
+            <xsd:element name="Map" type="Map" minOccurs="0" maxOccurs="1"/>
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="Pump"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>Pumps</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        The Pump element is a reference to a LightSource.  It is used within the Laser element to specify the light source for the laser's pump (if any).
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="Reference">
+          <xsd:attribute name="ID" use="required" type="LightSourceID"/>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="Rights"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>Rights</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        The rights holder of this data and the rights held.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element name="RightsHolder" minOccurs="0" maxOccurs="1">
+          <xsd:annotation>
+            <xsd:documentation> The rights holder for this data. [plain-text multi-line string]
+            e.g. "Copyright (C) 2002 - 2016 Open Microscopy Environment"
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:whiteSpace value="preserve"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element name="RightsHeld" minOccurs="0" maxOccurs="1">
+          <xsd:annotation>
+            <xsd:documentation>
+              The rights held by the rights holder. [plain-text multi-line string]
+              e.g. "All rights reserved" or "Creative Commons Attribution 3.0 Unported License"
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:whiteSpace value="preserve"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- References -->
+  <xsd:complexType name="Reference">
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><abstract/></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        Reference is an empty complex type that is contained and extended by all the *Ref elements and also the Settings Complex Type
+        Each *Ref element defines an attribute named ID of simple type *ID and no other information
+        Each simple type *ID is restricted to the base type LSID with an appropriate pattern
+      </xsd:documentation>
+    </xsd:annotation>
+  </xsd:complexType>
+
+  <xsd:element name="ImageRef"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:documentation>
+        The ImageRef element is a reference to an Image element.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="Reference">
+          <xsd:attribute name="ID" use="required" type="ImageID"/>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:complexType name="FilterRef" > <!-- top level definition -->
+    <xsd:complexContent>
+      <xsd:extension base="Reference">
+        <xsd:attribute name="ID" use="required" type="FilterID"/>
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+
+  <xsd:element name="MicrobeamManipulationRef"> <!-- top level definition -->
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="Reference">
+          <xsd:attribute name="ID" use="required" type="MicrobeamManipulationID"/>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="ExperimentRef"> <!-- top level definition -->
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="Reference">
+          <xsd:attribute name="ID" use="required" type="ExperimentID"/>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="ChannelRef"> <!-- top level definition -->
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="Reference">
+          <xsd:attribute name="ID" use="required" type="ChannelID"/>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="ProjectRef"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:documentation>
+        There may be one or more of these in a Dataset.
+        This empty element has a required Project ID attribute that refers to Projects defined within the OME element.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="Reference">
+          <xsd:attribute name="ID" use="required" type="ProjectID"/>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="ExperimenterRef"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:documentation>
+        This empty element has a required Experimenter ID and an optional DocumentID attribute which refers to one of the Experimenters defined within OME.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="Reference">
+          <xsd:attribute name="ID" use="required" type="ExperimenterID"/>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="ExperimenterGroupRef"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:documentation>This empty element has a reference (the ExperimenterGroup ID attribute) to a ExperimenterGroup defined within OME.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="Reference">
+          <xsd:attribute name="ID" use="required" type="ExperimenterGroupID"/>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="InstrumentRef"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:documentation>
+        This empty element can be used (via the required Instrument ID attribute) to refer to an Instrument defined within OME.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="Reference">
+          <xsd:attribute name="ID" use="required" type="InstrumentID"/>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="DatasetRef"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:documentation>
+        The DatasetRef element refers to a Dataset by specifying the Dataset ID attribute.
+        One or more DatasetRef elements may be listed within the Image element to specify what Datasets
+        the Image belongs to.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="Reference">
+          <xsd:attribute name="ID" use="required" type="DatasetID"/>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="FolderRef"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:documentation>
+        The FolderRef element refers to a Folder by specifying the Folder ID attribute.
+        One or more FolderRef elements may be listed within the Folder element to specify what Folders
+        the Folder contains. This tree hierarchy must be acyclic.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="Reference">
+          <xsd:attribute name="ID" use="required" type="FolderID"/>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="FilterSetRef"> <!-- top level definition -->
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="Reference">
+          <xsd:attribute name="ID" use="required" type="FilterSetID"/>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- Settings -->
+  <xsd:complexType name="Settings">
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><abstract/></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        Settings is an empty complex type that is contained and extended by all the *Settings elements
+        Each *Settings element defines an attribute named ID of simple type *ID and the other information that is needed.
+        Each simple type *ID is restricted to the base type LSID with an appropriate pattern
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexContent>
+      <xsd:extension base="Reference">
+      </xsd:extension>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:element name="LightSourceSettings"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>LightSourceSettingsCombinations</plural></xsdfu></xsd:appinfo>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="Settings">
+          <xsd:attribute name="ID" use="required" type="LightSourceID"/>
+          <xsd:attribute name="Attenuation" use="optional" type="PercentFraction">
+            <xsd:annotation>
+              <xsd:documentation>
+                The Attenuation of the light source [units:none]
+                A fraction, as a value from 0.0 to 1.0.
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="Wavelength" use="optional" type="PositiveFloat">
+            <xsd:annotation>
+              <xsd:documentation>
+                The Wavelength of the light source. Units are set by WavelengthUnit.
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="WavelengthUnit" use="optional" default="nm" type="UnitsLength">
+            <xsd:annotation>
+              <xsd:documentation>
+                The units of the Wavelength of the light source - default:nanometres[nm]
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="DetectorSettings"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>DetectorSettingsCombinations</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        This holds the setting applied to a detector as well as a
+        reference to the detector.
+        The ID is the detector used in this case.
+        The values stored in DetectorSettings represent the variable values,
+        fixed values not modified during the acquisition go in Detector.
+
+        Each attribute now has an indication of what type of detector
+        it applies to. This is preparatory work for cleaning up and
+        possibly splitting this object into sub-types.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="Settings">
+          <xsd:attribute name="ID" use="required" type="DetectorID"/>
+          <xsd:attribute name="Offset" use="optional" type="xsd:float">
+            <xsd:annotation>
+              <xsd:documentation>
+                The Offset of the detector. [units none] {used:CCD,EMCCD}
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="Gain" use="optional" type="xsd:float">
+            <xsd:annotation>
+              <xsd:documentation>
+                The Gain of the detector. [units:none] {used:CCD,EMCCD,PMT}
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="Voltage" use="optional" type="xsd:float">
+            <xsd:annotation>
+              <xsd:documentation>
+                The Voltage of the detector. {used:PMT}
+                Units are set by VoltageUnit.
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="VoltageUnit" use="optional" default="V" type="UnitsElectricPotential">
+            <xsd:annotation>
+              <xsd:documentation>
+                The units of the Voltage of the detector - default:volts[V]
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="Zoom" use="optional" type="xsd:float">
+            <xsd:annotation>
+              <xsd:documentation>
+                The Zoom or "Confocal Zoom" or "Scan Zoom" for a detector. [units:none] {used:PMT}
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="ReadOutRate" use="optional" type="xsd:float">
+            <xsd:annotation>
+              <xsd:documentation>
+                The speed at which the detector can count pixels.  {used:CCD,EMCCD}
+                This is the bytes per second that
+                can be read from the detector (like a baud rate).
+                Units are set by ReadOutRateUnit.
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="ReadOutRateUnit" use="optional" default="MHz" type="UnitsFrequency">
+            <xsd:annotation>
+              <xsd:documentation>The units of the ReadOutRate - default:megahertz[Hz].</xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="Binning" use="optional" type="Binning">
+            <xsd:annotation>
+              <xsd:documentation>
+                Represents the number of pixels that are combined to form larger pixels. {used:CCD,EMCCD}
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="Integration" use="optional" type="PositiveInt">
+            <xsd:annotation>
+              <xsd:documentation>
+                This is the number of sequential frames that get averaged,
+                to improve the signal-to-noise ratio. [units:none] {used:CCD,EMCCD}
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="ObjectiveSettings"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>ObjectiveSettingsCombinations</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        This holds the setting applied to an objective as well as a
+        reference to the objective.
+        The ID is the objective used in this case.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="Settings">
+          <xsd:attribute name="ID" use="required" type="ObjectiveID"/>
+          <xsd:attribute name="CorrectionCollar" use="optional" type="xsd:float">
+            <xsd:annotation>
+              <xsd:documentation>
+                The CorrectionCollar is normally an adjustable ring on the
+                objective. Each has an arbitrary scale on it so the values
+                is unit-less. [units:none]
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="Medium" use="optional">
+            <xsd:simpleType>
+              <xsd:annotation>
+                <xsd:documentation>
+                  A description of a Medium used for the lens.
+                  The Medium is the actual immersion medium used in this case.
+                </xsd:documentation>
+              </xsd:annotation>
+              <xsd:restriction base="xsd:string">
+                <xsd:enumeration value="Air"/>
+                <xsd:enumeration value="Oil"/>
+                <xsd:enumeration value="Water"/>
+                <xsd:enumeration value="Glycerol"/>
+                <xsd:enumeration value="Other"/>
+              </xsd:restriction>
+            </xsd:simpleType>
+          </xsd:attribute>
+          <xsd:attribute name="RefractiveIndex" use="optional" type="xsd:float">
+            <xsd:annotation>
+              <xsd:documentation>
+                The RefractiveIndex is that of the immersion medium. This is
+                a ratio so it also unit-less. [units:none]
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- ID types -->
+  <xsd:simpleType name="LSID">
+    <xsd:annotation>
+      <xsd:documentation>
+        Either LSID or internal consistent IDs for the file
+        See: http://www.openmicroscopy.org/site/support/file-formats/working-with-ome-xml/id-and-lsid
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string">
+      <xsd:pattern value="(urn:lsid:([\w\-\.]+\.[\w\-\.]+)+:\S+:\S+)|(\S+:\S+)"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ProjectID">
+    <xsd:restriction base="LSID">
+      <xsd:pattern value="(urn:lsid:([\w\-\.]+\.[\w\-\.]+)+:Project:\S+)|(Project:\S+)"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="DatasetID">
+    <xsd:restriction base="LSID">
+      <xsd:pattern value="(urn:lsid:([\w\-\.]+\.[\w\-\.]+)+:Dataset:\S+)|(Dataset:\S+)"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ImageID">
+    <xsd:restriction base="LSID">
+      <xsd:pattern value="(urn:lsid:([\w\-\.]+\.[\w\-\.]+)+:Image:\S+)|(Image:\S+)"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="FolderID">
+    <xsd:restriction base="LSID">
+      <xsd:pattern value="(urn:lsid:([\w\-\.]+\.[\w\-\.]+)+:Folder:\S+)|(Folder:\S+)"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ExperimenterID">
+    <xsd:restriction base="LSID">
+      <xsd:pattern value="(urn:lsid:([\w\-\.]+\.[\w\-\.]+)+:Experimenter:\S+)|(Experimenter:\S+)"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ExperimenterGroupID">
+    <xsd:restriction base="LSID">
+      <xsd:pattern value="(urn:lsid:([\w\-\.]+\.[\w\-\.]+)+:ExperimenterGroup:\S+)|(ExperimenterGroup:\S+)"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ExperimentID">
+    <xsd:restriction base="LSID">
+      <xsd:pattern value="(urn:lsid:([\w\-\.]+\.[\w\-\.]+)+:Experiment:\S+)|(Experiment:\S+)"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="MicrobeamManipulationID">
+    <xsd:restriction base="LSID">
+      <xsd:pattern value="(urn:lsid:([\w\-\.]+\.[\w\-\.]+)+:MicrobeamManipulation:\S+)|(MicrobeamManipulation:\S+)"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="InstrumentID">
+    <xsd:restriction base="LSID">
+      <xsd:pattern value="(urn:lsid:([\w\-\.]+\.[\w\-\.]+)+:Instrument:\S+)|(Instrument:\S+)"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ObjectiveID">
+    <xsd:restriction base="LSID">
+      <xsd:pattern value="(urn:lsid:([\w\-\.]+\.[\w\-\.]+)+:Objective:\S+)|(Objective:\S+)"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="LightSourceID">
+    <xsd:restriction base="LSID">
+      <xsd:pattern value="(urn:lsid:([\w\-\.]+\.[\w\-\.]+)+:LightSource:\S+)|(LightSource:\S+)"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="DichroicID">
+    <xsd:restriction base="LSID">
+      <xsd:pattern value="(urn:lsid:([\w\-\.]+\.[\w\-\.]+)+:Dichroic:\S+)|(Dichroic:\S+)"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="FilterID">
+    <xsd:restriction base="LSID">
+      <xsd:pattern value="(urn:lsid:([\w\-\.]+\.[\w\-\.]+)+:Filter:\S+)|(Filter:\S+)"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="FilterSetID">
+    <xsd:restriction base="LSID">
+      <xsd:pattern value="(urn:lsid:([\w\-\.]+\.[\w\-\.]+)+:FilterSet:\S+)|(FilterSet:\S+)"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="DetectorID">
+    <xsd:restriction base="LSID">
+      <xsd:pattern value="(urn:lsid:([\w\-\.]+\.[\w\-\.]+)+:Detector:\S+)|(Detector:\S+)"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="PixelsID">
+    <xsd:restriction base="LSID">
+      <xsd:pattern value="(urn:lsid:([\w\-\.]+\.[\w\-\.]+)+:Pixels:\S+)|(Pixels:\S+)"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ChannelID">
+    <xsd:restriction base="LSID">
+      <xsd:pattern value="(urn:lsid:([\w\-\.]+\.[\w\-\.]+)+:Channel:\S+)|(Channel:\S+)"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+  <xsd:simpleType name="ModuleID">
+    <xsd:restriction base="LSID">
+      <xsd:pattern value="(urn:lsid:([\w\-\.]+\.[\w\-\.]+)+:Module:\S+)|(Module:\S+)"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <!-- BinaryFile -->
+  <xsd:simpleType name="base64Binary">
+    <xsd:restriction base="xsd:base64Binary"/>
+  </xsd:simpleType>
+  <xsd:element name = "External"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>Externals</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>Describes a file location.  Can optionally specify a portion of a file using Offset and a ReadLength.
+      If Offset and ReadLength are specified in conjunction with Compression, then they point into the uncompressed file.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:attribute name = "href" use = "required" type = "xsd:anyURI">
+        <xsd:annotation>
+          <xsd:documentation>file location</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name = "SHA1" use = "required" type = "Hex40">
+        <xsd:annotation>
+          <xsd:documentation>The digest of the file specified in href.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name = "Compression" default = "none" use="optional">
+        <xsd:annotation>
+          <xsd:documentation>Specifies the compression scheme used to encode the data.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleType>
+          <xsd:restriction base = "xsd:string">
+            <xsd:enumeration value = "zlib"/>
+            <xsd:enumeration value = "bzip2"/>
+            <xsd:enumeration value = "none"/>
+          </xsd:restriction>
+        </xsd:simpleType>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name = "BinData"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>BinDataBlocks</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>The contents of this element are base64-encoded.  These are not CDATA sections, just a base64 stream.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:simpleContent>
+        <xsd:extension base = "base64Binary">
+          <xsd:attribute name = "Compression" default = "none" use="optional">
+            <xsd:annotation>
+              <xsd:documentation>Specifies the compression scheme used to encode the data. </xsd:documentation>
+            </xsd:annotation>
+            <xsd:simpleType>
+              <xsd:restriction base = "xsd:string">
+                <xsd:enumeration value = "zlib"/>
+                <xsd:enumeration value = "bzip2"/>
+                <xsd:enumeration value = "none"/>
+              </xsd:restriction>
+            </xsd:simpleType>
+          </xsd:attribute>
+          <xsd:attribute name="BigEndian" use="required" type="xsd:boolean">
+            <xsd:annotation>
+              <xsd:documentation>
+                This is true if the binary data was written in BigEndian order. This is dependent on the system architecture of the machine that wrote the pixels. True for essentially all modern CPUs other than Intel and Alpha. All Binary data must be written in the same endian order.
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="Length" use="required">
+            <xsd:annotation>
+              <xsd:documentation>
+                Character count attribute for the BinData field. This is the length of the base-64 encoded block. It allows easy skipping of the block when parsing the file. [unit:bytes]
+              </xsd:documentation>
+            </xsd:annotation>
+            <xsd:simpleType>
+              <xsd:restriction base="NonNegativeLong">
+              </xsd:restriction>
+            </xsd:simpleType>
+          </xsd:attribute>
+        </xsd:extension>
+      </xsd:simpleContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name = "BinaryFile"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>BinaryFiles</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>Describes a binary file.</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:choice minOccurs="1" maxOccurs="1">
+        <xsd:element ref="External" minOccurs="1" maxOccurs="1"/>
+        <xsd:element ref="BinData" minOccurs="1" maxOccurs="1"/>
+      </xsd:choice>
+      <xsd:attribute name ="FileName" use="required" type="xsd:string"/>
+      <xsd:attribute name ="Size" use="required" type="NonNegativeLong">
+        <xsd:annotation>
+          <xsd:documentation>
+            Size of the uncompressed file. [unit:bytes]
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="MIMEType" use="optional" type="xsd:string"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- SA -->
+  <!-- Annotatable objects
+       Annotation
+       Channel
+       Dataset
+       Experimenter
+       ExperimenterGroup
+       Folder
+       Image
+       Node
+       OriginalFile
+       Pixels
+       PlaneInfo
+       Plate
+       Project
+       Reagent
+       Roi
+       Screen
+       ScreenAcquisition
+       Session
+       Well
+       WellSample
+
+Node ?
+OriginalFile ?
+Session ?
+PlaneInfo (as Plane)
+  -->
+
+  <xsd:element name="StructuredAnnotations"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:documentation>
+        An unordered collection of annotation attached to objects in the OME data model.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:choice minOccurs="0" maxOccurs="unbounded">
+        <xsd:element ref="XMLAnnotation" minOccurs="1" maxOccurs="1"/>
+        <xsd:element ref="FileAnnotation" minOccurs="1" maxOccurs="1"/>
+        <xsd:element ref="ListAnnotation" minOccurs="1" maxOccurs="1"/>
+        <xsd:element ref="LongAnnotation" minOccurs="1" maxOccurs="1"/>
+        <xsd:element ref="DoubleAnnotation" minOccurs="1" maxOccurs="1"/>
+        <xsd:element ref="CommentAnnotation" minOccurs="1" maxOccurs="1"/>
+        <xsd:element ref="BooleanAnnotation" minOccurs="1" maxOccurs="1"/>
+        <xsd:element ref="TimestampAnnotation" minOccurs="1" maxOccurs="1"/>
+        <xsd:element ref="TagAnnotation" minOccurs="1" maxOccurs="1"/>
+        <xsd:element ref="TermAnnotation" minOccurs="1" maxOccurs="1"/>
+        <xsd:element ref="MapAnnotation" minOccurs="1" maxOccurs="1"/>
+      </xsd:choice>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="AnnotationRef"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:documentation>
+        The AnnotationRef element is a reference to an element derived
+        from the CommonAnnotation element.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="Reference">
+          <xsd:attribute name="ID" use="required" type="AnnotationID"/>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- the base annotation that all others are ultimately derived from -->
+  <xsd:complexType name="Annotation"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>Annotations</plural><abstract/></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        An annotation from which all others are ultimately derived.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="Description" minOccurs="0" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+            A description for the annotation. [plain-text multi-line string]
+          </xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleType>
+          <xsd:restriction base="xsd:string">
+            <xsd:whiteSpace value="preserve"/>
+          </xsd:restriction>
+        </xsd:simpleType>
+      </xsd:element>
+      <xsd:sequence>
+        <xsd:element ref="AnnotationRef" minOccurs="0" maxOccurs="unbounded">
+          <xsd:annotation>
+            <xsd:appinfo><xsdfu xmlns=""><manytomany/></xsdfu></xsd:appinfo>
+          </xsd:annotation>
+        </xsd:element>
+      </xsd:sequence>
+    </xsd:sequence>
+    <xsd:attribute name="ID" use="required" type="AnnotationID"></xsd:attribute>
+    <xsd:attribute name="Namespace" use="optional" type="xsd:anyURI">
+      <xsd:annotation>
+        <xsd:documentation>
+          We recommend the inclusion of a namespace for annotations you
+          define. If it is absent then we assume the annotation is to
+          use our (OME's) default interpretation for this type.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="Annotator" use="optional" type="ExperimenterID">
+      <xsd:annotation>
+        <xsd:documentation>
+          The Annotator is the person who attached this annotation.
+          e.g. If UserA annotates something with TagB, owned by UserB,
+          UserA is still the Annotator.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+  </xsd:complexType>
+  <xsd:simpleType name="AnnotationID">
+    <xsd:restriction base="LSID">
+      <xsd:pattern value="(urn:lsid:([\w\-\.]+\.[\w\-\.]+)+:Annotation:\S+)|(Annotation:\S+)"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <!-- Intermediate abstract annotations, not used directly -->
+  <xsd:complexType name="BasicAnnotation"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>BasicAnnotations</plural><abstract/></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        An abstract Basic Annotation from which some others are derived.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexContent>
+      <xsd:extension base="Annotation"/>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:complexType name="NumericAnnotation"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>NumericAnnotations</plural><abstract/></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        An abstract Numeric Annotation from which some others are derived.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexContent>
+      <xsd:extension base="BasicAnnotation"/>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:complexType name="TextAnnotation"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>TextAnnotations</plural><abstract/></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        An abstract Text Annotation from which some others are derived.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexContent>
+      <xsd:extension base="Annotation"/>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:complexType name="TypeAnnotation"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>TypeAnnotations</plural><abstract/></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        An abstract Type Annotation from which some others are derived.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexContent>
+      <xsd:extension base="Annotation"/>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <!-- end of abstract annotations -->
+
+  <!-- The annotations used in the instance documents -->
+  <xsd:element name="FileAnnotation"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>FileAnnotations</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        A file object annotation
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="TypeAnnotation">
+          <xsd:sequence>
+            <xsd:element ref="BinaryFile" minOccurs="1" maxOccurs="1"/>
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="XMLAnnotation"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>XMLAnnotations</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        An general xml annotation. The contents of this is not processed as OME XML but should still be well-formed XML.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="TextAnnotation">
+          <xsd:sequence>
+            <xsd:element name="Value" minOccurs="1" maxOccurs="1">
+              <xsd:complexType>
+                <xsd:sequence>
+                  <xsd:any processContents = "lax" minOccurs = "0" maxOccurs = "unbounded"/>
+                </xsd:sequence>
+              </xsd:complexType>
+            </xsd:element>
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="ListAnnotation">  <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>ListAnnotations</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        This annotation is a grouping object. It uses the sequence of
+        annotation refs from the base Annotation to form the list.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="Annotation"/>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="CommentAnnotation"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>CommentAnnotations</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        A simple comment annotation
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="TextAnnotation">
+          <xsd:sequence>
+            <xsd:element name="Value" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="LongAnnotation"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>LongAnnotations</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        A simple numerical annotation of type xsd:long
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="NumericAnnotation">
+          <xsd:sequence>
+            <xsd:element name="Value" type="xsd:long" minOccurs="1" maxOccurs="1"/>
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="DoubleAnnotation"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>DoubleAnnotations</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        A simple numerical annotation of type xsd:double
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="NumericAnnotation">
+          <xsd:sequence>
+            <xsd:element name="Value" type="xsd:double" minOccurs="1" maxOccurs="1"/>
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="BooleanAnnotation"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>BooleanAnnotations</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        A simple boolean annotation of type xsd:boolean
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="BasicAnnotation">
+          <xsd:sequence>
+            <xsd:element name="Value" type="xsd:boolean" minOccurs="1" maxOccurs="1"/>
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="TimestampAnnotation"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>TimestampAnnotations</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        A date/time annotation of type xsd:dateTime
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="BasicAnnotation">
+          <xsd:sequence>
+            <xsd:element name="Value" type="xsd:dateTime" minOccurs="1" maxOccurs="1"/>
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="TagAnnotation"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>TagAnnotations</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        A tag annotation (represents a tag or a tagset)
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="TextAnnotation">
+          <xsd:sequence>
+            <xsd:element name="Value" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="TermAnnotation"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>TermAnnotations</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        A ontology term annotation
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="BasicAnnotation">
+          <xsd:sequence>
+            <xsd:element name="Value" type="xsd:string" minOccurs="1" maxOccurs="1"/>
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="MapAnnotation"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>MapAnnotations</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        An map annotation. The contents of this is a list of key/value pairs.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="Annotation">
+          <xsd:sequence>
+            <xsd:element name="Value" type="Map" minOccurs="1" maxOccurs="1"/>
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- ROI -->
+  <xsd:element name="ROI"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>ROIs</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        A four dimensional 'Region of Interest'.
+        If they are not used, and the Image has more than one plane,
+        the entire set of planes is assumed to be included in the ROI.
+        Multiple ROIs may be specified.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:choice minOccurs="1" maxOccurs="1">
+          <xsd:element name="Union" minOccurs="1" maxOccurs="1">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element ref="ShapeGroup" minOccurs="1" maxOccurs="unbounded"/>
+              </xsd:sequence>
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+        <xsd:element ref="AnnotationRef" minOccurs="0" maxOccurs="unbounded">
+          <xsd:annotation>
+            <xsd:appinfo><xsdfu xmlns=""><manytomany/></xsdfu></xsd:appinfo>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element name="Description" minOccurs="0" maxOccurs="1">
+          <xsd:annotation>
+            <xsd:documentation>
+              A description for the ROI. [plain-text multi-line string]
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:whiteSpace value="preserve"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+      </xsd:sequence>
+      <xsd:attribute name="ID" use="required" type="ROIID"/>
+      <xsd:attribute name="Name" use="optional" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            The Name identifies the ROI to the user. [plain-text string]
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="ShapeGroup" abstract="true" type="Shape"/>  <!-- top level definition -->
+  <xsd:complexType name="Shape">
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>Shapes</plural><abstract/></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        The shape element contains a single specific ROI shape and links
+        that to any channels, and a timepoint and a z-section. It also
+        records any transform applied to the ROI shape.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="Transform" type="AffineTransform" minOccurs="0" maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+            This is a matrix used to transform the shape.
+            The element has 6 xsd:float attributes. If the element
+            is present then all 6 values must be included.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element ref="AnnotationRef" minOccurs="0" maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:appinfo><xsdfu xmlns=""><manytomany/></xsdfu></xsd:appinfo>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="FillColor" use="optional" type="Color">
+      <xsd:annotation>
+        <xsd:documentation>
+          The color of the fill - encoded as RGBA
+          The value "-1" is #FFFFFFFF so solid white (it is a signed 32 bit value)
+          NOTE: Prior to the 2012-06 schema the default value was incorrect and produced a transparent red not solid white.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="FillRule" use="optional">
+      <xsd:simpleType>
+        <xsd:annotation>
+          <xsd:documentation>
+            The rule used to decide which parts of the shape to
+            fill. [enumeration]
+          </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+          <xsd:enumeration value="EvenOdd"/>
+          <xsd:enumeration value="NonZero"/>
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:attribute>
+    <xsd:attribute name="StrokeColor" use="optional" type="Color">
+      <xsd:annotation>
+        <xsd:documentation>
+          The color of the stroke  - encoded as RGBA
+          The value "-1" is #FFFFFFFF so solid white (it is a signed 32 bit value)
+          NOTE: Prior to the 2012-06 schema the default value was incorrect and produced a transparent red not solid white.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="StrokeWidth" use="optional" type="xsd:float">
+      <xsd:annotation>
+        <xsd:documentation>
+          The width of the stroke. Units are set by StrokeWidthUnit.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="StrokeWidthUnit" use="optional" default="pixel" type="UnitsLength">
+      <xsd:annotation>
+        <xsd:documentation>
+          The units used for the stroke width.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="StrokeDashArray" use="optional" type="xsd:string">
+      <xsd:annotation>
+        <xsd:documentation>
+          e.g. "none", "10 20 30 10"
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="Text" use="optional" type="xsd:string"/>
+    <xsd:attribute name="FontFamily" use="optional">
+      <xsd:simpleType>
+        <xsd:annotation>
+          <xsd:documentation>
+            The font family used to draw the text. [enumeration]
+            Note: these values are all lower case so they match
+            the standard HTML/CSS values. "fantasy" has been
+            included for completeness; we do not recommend its
+            regular use. This attribute is under consideration
+            for removal from the OME-XML schema.
+          </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+          <xsd:enumeration value="serif"/>
+          <xsd:enumeration value="sans-serif"/>
+          <xsd:enumeration value="cursive"/>
+          <xsd:enumeration value="fantasy"/>
+          <xsd:enumeration value="monospace"/>
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:attribute>
+    <xsd:attribute name="FontSize" use="optional" type="NonNegativeInt">
+      <xsd:annotation>
+        <xsd:documentation>
+          Size of the font. Units are set by FontSizeUnit.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="FontSizeUnit" use="optional" default="pt" type="UnitsLength">
+      <xsd:annotation>
+        <xsd:documentation>
+          The units used for the font size.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="FontStyle" use="optional">
+      <xsd:simpleType>
+        <xsd:annotation>
+          <xsd:documentation>
+            The style and weight applied to the text.  [enumeration]
+            This is a simplified combination of the HTML/CSS
+            attributes font-style AND font-weight.
+          </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+          <xsd:enumeration value="Bold"/>
+          <xsd:enumeration value="BoldItalic"/>
+          <xsd:enumeration value="Italic"/>
+          <xsd:enumeration value="Normal"/>
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:attribute>
+    <xsd:attribute name="Locked" use="optional" type="xsd:boolean">
+      <xsd:annotation>
+        <xsd:documentation>
+          Controls whether the shape is locked and read only,
+          true is locked, false is editable.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="ID" use="required" type="ShapeID"/>
+    <xsd:attribute name="TheZ" use="optional" type="NonNegativeInt">
+      <xsd:annotation>
+        <xsd:documentation>
+          The z-section the ROI applies to. If not specified then
+          the ROI applies to all the z-sections of the image. [units:none]
+          This is numbered from 0.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="TheT" use="optional" type="NonNegativeInt">
+      <xsd:annotation>
+        <xsd:documentation>
+          The timepoint the ROI applies to. If not specified then
+          the ROI applies to all the timepoints of the image. [units:none]
+          This is numbered from 0.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="TheC" use="optional" type="NonNegativeInt">
+      <xsd:annotation>
+        <xsd:documentation>
+          The channel the ROI applies to. If not specified then
+          the ROI applies to all the channels of the image. [units:none]
+          This is numbered from 0.
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+  </xsd:complexType>
+
+  <xsd:element name="Rectangle" substitutionGroup="ShapeGroup"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>Rectangles</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        A simple rectangle object. If rotation is required apply a
+        transformation at the Shape level.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="Shape">
+          <xsd:attribute name="X" use="required" type="xsd:float">
+            <xsd:annotation>
+              <xsd:documentation>
+                The X value of the left edge or the rectangle. [units pixels]
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="Y" use="required" type="xsd:float">
+            <xsd:annotation>
+              <xsd:documentation>
+                The y value of the top edge or the rectangle. [units pixels]
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="Width" use="required" type="xsd:float">
+            <xsd:annotation>
+              <xsd:documentation>
+                The width of the rectangle. [units pixels]
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="Height" use="required" type="xsd:float">
+            <xsd:annotation>
+              <xsd:documentation>
+                The height of the rectangle. [units pixels]
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="Mask" substitutionGroup="ShapeGroup"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>Masks</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        The Mask ROI shape is a link to a BinData object that is
+        a BIT mask drawn on top of the image as an ROI. It is applied
+        at the same scale, pixel to pixel, as the Image the ROI is
+        applied to, unless a transform is applied at the shape level.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="Shape">
+          <xsd:sequence>
+            <xsd:element ref="BinData" minOccurs="1" maxOccurs="1"/>
+          </xsd:sequence>
+          <xsd:attribute name="X" use="required" type="xsd:float">
+            <xsd:annotation>
+              <xsd:documentation>
+                The X coordinate of the left side of the image. [units pixels]
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="Y" use="required" type="xsd:float">
+            <xsd:annotation>
+              <xsd:documentation>
+                The Y coordinate of the top side of the image. [units pixels]
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="Width" use="required" type="xsd:float">
+            <xsd:annotation>
+              <xsd:documentation>
+                The width of the mask. [units pixels]
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="Height" use="required" type="xsd:float">
+            <xsd:annotation>
+              <xsd:documentation>
+                The height of the mask. [units pixels]
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="Point" substitutionGroup="ShapeGroup"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>Points</plural></xsdfu></xsd:appinfo>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="Shape">
+          <xsd:attribute name="X" use="required" type="xsd:float">
+            <xsd:annotation>
+              <xsd:documentation>
+                The X coordinate of the point. [units pixels]
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="Y" use="required" type="xsd:float">
+            <xsd:annotation>
+              <xsd:documentation>
+                The Y coordinate of the point. [units pixels]
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="Ellipse" substitutionGroup="ShapeGroup"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>Ellipses</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        A simple ellipse object. If rotation is required apply a
+        transformation at the Shape level.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="Shape">
+          <xsd:attribute name="X" use="required" type="xsd:float">
+            <xsd:annotation>
+              <xsd:documentation>
+                The X coordinate of the center of the ellipse. [units pixels]
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="Y" use="required" type="xsd:float">
+            <xsd:annotation>
+              <xsd:documentation>
+                The Y coordinate of the center of the ellipse. [units pixels]
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="RadiusX" use="required" type="xsd:float">
+            <xsd:annotation>
+              <xsd:documentation>
+                The horizontal radius of the ellipse. [units pixels]
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="RadiusY" use="required" type="xsd:float">
+            <xsd:annotation>
+              <xsd:documentation>
+                The vertical radius of the ellipse. [units pixels]
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="Line" substitutionGroup="ShapeGroup"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>Lines</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        A straight line defined by it's end points.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="Shape">
+          <xsd:attribute name="X1" use="required" type="xsd:float">
+            <xsd:annotation>
+              <xsd:documentation> The X coordinate of the start of the line. [units pixels]
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="Y1" use="required" type="xsd:float">
+            <xsd:annotation>
+              <xsd:documentation> The Y coordinate of the start of the line. [units pixels]
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="X2" use="required" type="xsd:float">
+            <xsd:annotation>
+              <xsd:documentation> The X coordinate of the end of the line. [units pixels]
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="Y2" use="required" type="xsd:float">
+            <xsd:annotation>
+              <xsd:documentation> The Y coordinate of the end of the line. [units pixels]
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="MarkerStart" use="optional" type="Marker"/>
+          <xsd:attribute name="MarkerEnd" use="optional" type="Marker"/>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="Polyline" substitutionGroup="ShapeGroup"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>Polylines</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        The Polyline defines open shapes formed of straight
+        lines. Note: Polyline uses counterclockwise winding (this is the
+        default OpenGL behavior)
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="Shape">
+          <xsd:attribute name="Points" use="required" type="xsd:string">
+            <xsd:annotation>
+              <xsd:documentation> The points of the polyline are defined as a list of comma
+              separated x,y coordinates separated by spaces like "x1,y1 x2,y2 x3,y3" e.g.
+              "0,0 1,2 3,5" </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="MarkerStart" use="optional" type="Marker"/>
+          <xsd:attribute name="MarkerEnd" use="optional" type="Marker"/>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="Polygon" substitutionGroup="ShapeGroup"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>Polygons</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        The Polygon defines closed shapes formed of straight
+        lines. Note: Polygon uses counterclockwise winding (this is the
+        default OpenGL behavior)
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="Shape">
+          <xsd:attribute name="Points" use="required" type="xsd:string">
+            <xsd:annotation>
+              <xsd:documentation> The points of the Polygon are defined as a list of comma
+              separated x,y coordinates separated by spaces like "x1,y1 x2,y2 x3,y3" e.g.
+              "0,0 1,2 3,5" </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="Label" substitutionGroup="ShapeGroup"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>Labels</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        The text label. Any transformation should be applied at the
+        shape level.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="Shape">
+          <xsd:attribute name="X" use="required" type="xsd:float">
+            <xsd:annotation>
+              <xsd:documentation> This defines the X coordinate of the current text position
+              of the first character in the string. [units pixels] </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+          <xsd:attribute name="Y" use="required" type="xsd:float">
+            <xsd:annotation>
+              <xsd:documentation> This defines the Y coordinate of the current text position
+              of the first character in the string. [units pixels] </xsd:documentation>
+            </xsd:annotation>
+          </xsd:attribute>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="ROIRef"> <!-- top level definition -->
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="Reference">
+          <xsd:attribute name="ID" use="required" type="ROIID"/>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+
+
+  <xsd:complexType name="AffineTransform">
+    <xsd:annotation>
+      <xsd:documentation>
+        A matrix used to transform the shape.
+        ⎡ A00, A01, A02 ⎤
+        ⎢ A10, A11, A12 ⎥
+        ⎣ 0,   0,   1   ⎦
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="A00" use="required" type="xsd:float"/>
+    <xsd:attribute name="A10" use="required" type="xsd:float"/>
+    <xsd:attribute name="A01" use="required" type="xsd:float"/>
+    <xsd:attribute name="A11" use="required" type="xsd:float"/>
+    <xsd:attribute name="A02" use="required" type="xsd:float"/>
+    <xsd:attribute name="A12" use="required" type="xsd:float"/>
+  </xsd:complexType>
+
+  <xsd:simpleType name="ROIID"> <!-- top level definition -->
+    <xsd:restriction base="LSID">
+      <xsd:pattern value="(urn:lsid:([\w\-\.]+\.[\w\-\.]+)+:\S+)|(\S+)"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="ShapeID"> <!-- top level definition -->
+    <xsd:restriction base="LSID">
+      <xsd:pattern value="(urn:lsid:([\w\-\.]+\.[\w\-\.]+)+:Shape:\S+)|(Shape:\S+)"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="Marker"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>Markers</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        Shape of marker on the end of a line. [enumeration]
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="Arrow"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <!-- SPW -->
+  <xsd:element name="Plate"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>Plates</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        This element identifies microtiter plates within a screen.
+        A plate can belong to more than one screen.
+        The Screen(s) that a plate belongs to are specified by the ScreenRef element.
+        The Plate ID and Name attributes are required.
+        The Wells in a plate are numbers from the top-left corner in a grid starting at zero.
+        i.e. The top-left well of a plate is index (0,0)
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element name="Description" minOccurs="0" maxOccurs="1">
+          <xsd:annotation>
+            <xsd:documentation>
+              A description for the plate.
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:whiteSpace value="preserve"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element ref="Well" minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element ref="AnnotationRef" minOccurs="0" maxOccurs="unbounded">
+          <xsd:annotation>
+            <xsd:appinfo><xsdfu xmlns=""><manytomany/></xsdfu></xsd:appinfo>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element ref="PlateAcquisition" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="ID" use="required" type="PlateID"/>
+      <xsd:attribute name="Name" use="optional" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            The Name identifies the plate to the user.
+            It is used much like the ID, and so must be
+            unique within the document.
+
+            If a plate name is not available when one is needed
+            it will be constructed in the following order:
+            1. If name is available use it.
+            2. If not use "Start time - End time"
+            (NOTE: Not a subtraction! A string representation
+            of the two times separated by a dash.)
+            3. If these times are not available use the Plate ID.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="Status" use="optional" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            A textual annotation of the current state of the plate with respect to the
+            experiment work-flow; e.g.
+            1. Seed cell: done; 2. Transfection: done;      3. Gel doc: todo.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="ExternalIdentifier" use="optional" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            The ExternalIdentifier attribute may contain a reference to an external database.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="ColumnNamingConvention" use="optional" type="NamingConvention">
+        <xsd:annotation>
+          <xsd:documentation>
+            The ColumnNamingConvention
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="RowNamingConvention" use="optional" type="NamingConvention">
+        <xsd:annotation>
+          <xsd:documentation>
+            The RowNamingConvention
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="WellOriginX" use="optional" type="xsd:float">
+        <xsd:annotation>
+          <xsd:documentation>
+            This defines the X position to use for the origin of the
+            fields (individual images) taken in a well. It is used
+            with the X in the WellSample to display the fields
+            in the correct position relative to each other. Each Well
+            in the plate has the same well origin. Units are set by WellOriginXUnit.
+
+            In the OMERO clients by convention we display the WellOrigin
+            in the center of the view.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="WellOriginXUnit" use="optional" default="reference frame" type="UnitsLength">
+        <xsd:annotation>
+          <xsd:documentation>The units of the well origin in X - default:reference frame.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="WellOriginY" use="optional" type="xsd:float">
+        <xsd:annotation>
+          <xsd:documentation>
+            This defines the Y position to use for the origin of the
+            fields (individual images) taken in a well. It is used
+            with the Y in the WellSample to display the fields
+            in the correct position relative to each other. Each Well
+            in the plate has the same well origin.  Units are set by WellOriginYUnit.
+
+            In the OMERO clients by convention we display the WellOrigin
+            in the center of the view.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="WellOriginYUnit" use="optional" default="reference frame" type="UnitsLength">
+        <xsd:annotation>
+          <xsd:documentation>The units of the well origin in Y - default:reference frame.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="Rows" use="optional" type="PositiveInt">
+        <xsd:annotation>
+          <xsd:documentation>
+            The number of rows in the plate
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="Columns" use="optional" type="PositiveInt">
+        <xsd:annotation>
+          <xsd:documentation>
+            The number of columns in the plate
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="FieldIndex" use="optional" type="NonNegativeInt">
+        <xsd:annotation>
+          <xsd:documentation>
+            The index of the WellSample to display as the default Field
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+    <!-- Unique Indexes -->
+    <xsd:key name="WellSampleIndex"><xsd:selector xpath="Well/WellSample"/><xsd:field xpath="@Index"/></xsd:key>
+
+  </xsd:element>
+
+  <xsd:simpleType name="NamingConvention">
+    <xsd:annotation>
+      <xsd:documentation>
+        Predefined list of values for the well labels
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="letter">
+        <xsd:annotation>
+          <xsd:documentation>
+            While the label type 'number' has a clear meaning the 'letter'
+            type is more complex.
+
+            If you have less than 26 values use letters A to Z.
+            Once you get more than 26 values there are several different
+            approaches in use.
+            One we have see include:
+
+            Single letter, then double letter each running A to Z, right first
+            e.g. A, B, C, ... X, Y, Z, AA, AB, AC, ... AY, AZ, BA, BB, ...
+            This is the format used by Microsoft Excel so users may be familiar with it.
+            This is the approach we use in the OMERO client applications.
+
+            CAPITALsmall, each running A to Z, small first
+            e.g. Aa, Ab, Ac, ... Ax, Ay, Az, Ba, Bb, Bc, ... By, Bz, Ca, Cb, ...
+            This is in use by some plate manufactures.
+
+            Single letter, then double letter, then triple letter, and so on
+            e.g. A, B, C, ... X, Y, Z, AA, BB, CC, ... YY, ZZ, AAA, BBB, ...
+            This has the advantage that the first 26 are the same as the standard
+            but has a problem an the labels get wider and wider leading to user
+            interface problems.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:enumeration>
+      <xsd:enumeration value="number">
+        <xsd:annotation>
+          <xsd:documentation>
+            1, 2, 3, ...
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:enumeration>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="PlateID">
+    <xsd:restriction base="LSID">
+      <xsd:pattern value="(urn:lsid:([\w\-\.]+\.[\w\-\.]+)+:Plate:\S+)|(Plate:\S+)"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:element name="Reagent"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>Reagents</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        Reagent is used to describe a chemical or some other physical experimental parameter.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element name="Description" minOccurs="0" maxOccurs="1">
+          <xsd:annotation>
+            <xsd:documentation>
+              A long description for the reagent.
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:whiteSpace value="preserve"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element ref="AnnotationRef" minOccurs="0" maxOccurs="unbounded">
+          <xsd:annotation>
+            <xsd:appinfo><xsdfu xmlns=""><manytomany/></xsdfu></xsd:appinfo>
+          </xsd:annotation>
+        </xsd:element>
+      </xsd:sequence>
+      <xsd:attribute name="ID" use="required" type="ReagentID"/>
+      <xsd:attribute name="Name" use="optional" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            A short name for the reagent
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="ReagentIdentifier" use="optional" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            This is a reference to an external (to OME) representation of the Reagent.
+            It serves as a foreign key into an external database. - It is sometimes referred to as ExternalIdentifier.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="ReagentRef"> <!-- top level definition -->
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="Reference">
+          <xsd:attribute name="ID" use="required" type="ReagentID"/>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:simpleType name="ReagentID">
+    <xsd:restriction base="LSID">
+      <xsd:pattern value="(urn:lsid:([\w\-\.]+\.[\w\-\.]+)+:Reagent:\S+)|(Reagent:\S+)"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:element name="Screen"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>Screens</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        The Screen element is a grouping for Plates.
+        The required attribute is the Screen's Name and ID - both must be unique within the document.
+        The Screen element may contain an ExternalRef attribute that refers to an external database.
+        A description of the screen may be specified in the Description element.
+        Screens may contain overlapping sets of Plates i.e.      Screens and Plates have a many-to-many relationship.
+        Plates contain one or more ScreenRef elements to specify what screens they belong to.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element name="Description" minOccurs="0" maxOccurs="1">
+          <xsd:annotation>
+            <xsd:documentation>
+              A description for the screen.
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:whiteSpace value="preserve"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element ref="Reagent" minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element name="PlateRef" minOccurs="0" maxOccurs="unbounded">
+          <xsd:annotation>
+            <xsd:appinfo><xsdfu xmlns=""><manytomany/></xsdfu></xsd:appinfo>
+            <xsd:documentation>
+              The PlateRef element is a reference to a Plate element.
+              Screen elements may have one or more PlateRef elements to define the plates that are part of the screen.
+              Plates may belong to more than one screen.
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:complexType>
+            <xsd:complexContent>
+              <xsd:extension base="Reference">
+                <xsd:attribute name="ID" use="required" type="PlateID"/>
+              </xsd:extension>
+            </xsd:complexContent>
+          </xsd:complexType>
+        </xsd:element>
+        <xsd:element ref="AnnotationRef" minOccurs="0" maxOccurs="unbounded">
+          <xsd:annotation>
+            <xsd:appinfo><xsdfu xmlns=""><manytomany/></xsdfu></xsd:appinfo>
+          </xsd:annotation>
+        </xsd:element>
+      </xsd:sequence>
+      <xsd:attribute name="ID" use="required" type="ScreenID"/>
+      <xsd:attribute name="Name" use="optional" type="xsd:string"/>
+      <xsd:attribute name="ProtocolIdentifier" use="optional" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            A pointer to an externally defined protocol, usually in a screening database.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="ProtocolDescription" use="optional" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            A description of the screen protocol; may contain very detailed information to
+            reproduce some of that found in a screening database.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="ReagentSetDescription" use="optional" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            A description of the set of reagents; may contain very detailed information to
+            reproduce some of that information found in a screening database.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="ReagentSetIdentifier" use="optional" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            A pointer to an externally defined set of reagents, usually in a screening
+            database/automation database.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="Type" use="optional" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            A human readable identifier for the screen type; e.g. RNAi, cDNA, SiRNA, etc.
+            This string is likely to become an enumeration in future releases.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:simpleType name="ScreenID">
+    <xsd:restriction base="LSID">
+      <xsd:pattern value="(urn:lsid:([\w\-\.]+\.[\w\-\.]+)+:Screen:\S+)|(Screen:\S+)"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:element name="PlateAcquisition"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>PlateAcquisitions</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        PlateAcquisition is used to describe a single acquisition run for a plate.
+        This object is used to record the set of images acquired in a single
+        acquisition run. The Images for this run are linked to PlateAcquisition
+        through WellSample.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element name="Description" minOccurs="0" maxOccurs="1">
+          <xsd:annotation>
+            <xsd:documentation>
+              A description for the PlateAcquisition.
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:simpleType>
+            <xsd:restriction base="xsd:string">
+              <xsd:whiteSpace value="preserve"/>
+            </xsd:restriction>
+          </xsd:simpleType>
+        </xsd:element>
+        <xsd:element ref="WellSampleRef" minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element ref="AnnotationRef" minOccurs="0" maxOccurs="unbounded">
+          <xsd:annotation>
+            <xsd:appinfo><xsdfu xmlns=""><manytomany/></xsdfu></xsd:appinfo>
+          </xsd:annotation>
+        </xsd:element>
+      </xsd:sequence>
+      <xsd:attribute name="ID" use="required" type="PlateAcquisitionID"/>
+      <xsd:attribute name="Name" use="optional" type="xsd:string"/>
+      <xsd:attribute name="EndTime" use="optional" type="xsd:dateTime">
+        <xsd:annotation>
+          <xsd:documentation>
+            Time when the last image of this acquisition was collected
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="StartTime" use="optional" type="xsd:dateTime">
+        <xsd:annotation>
+          <xsd:documentation>
+            Time when the first image of this acquisition was collected
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="MaximumFieldCount" use="optional" type="PositiveInt">
+        <xsd:annotation>
+          <xsd:documentation>
+            The maximum number of fields (well samples) in any well
+            in this PlateAcquisition.
+            This is only used to speed up user interaction by stopping
+            the reading of every well sample.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:simpleType name="PlateAcquisitionID">
+    <xsd:restriction base="LSID">
+      <xsd:pattern value="(urn:lsid:([\w\-\.]+\.[\w\-\.]+)+:PlateAcquisition:\S+)|(PlateAcquisition:\S+)"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:element name="Well"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>Wells</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        A Well is a component of the Well/Plate/Screen construct to describe screening applications.
+        A Well has a number of WellSample elements that link to the Images collected in this well.
+        The ReagentRef links any Reagents that were used in this Well. A well is part of only one Plate.
+        The origin for the row and column identifiers is the top left corner of the plate starting at zero.
+        i.e The top left well of a plate is index (0,0)
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="WellSample" minOccurs="0" maxOccurs="unbounded">
+          <xsd:annotation>
+            <xsd:appinfo><xsdfu xmlns=""><ordered/></xsdfu></xsd:appinfo>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element ref="ReagentRef" minOccurs="0" maxOccurs="1"/>
+        <xsd:element ref="AnnotationRef" minOccurs="0" maxOccurs="unbounded">
+          <xsd:annotation>
+            <xsd:appinfo><xsdfu xmlns=""><manytomany/></xsdfu></xsd:appinfo>
+          </xsd:annotation>
+        </xsd:element>
+      </xsd:sequence>
+      <xsd:attribute name="ID" use="required" type="WellID"/>
+      <xsd:attribute name="Column" use="required" type="NonNegativeInt">
+        <xsd:annotation>
+          <xsd:documentation>
+            This is the column index of the well, the origin is the top left corner of the plate
+            with the first column of cells being column zero. i.e top left is (0,0)
+            The combination of Row, Column has to be unique for each well in a plate.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="Row" use="required" type="NonNegativeInt">
+        <xsd:annotation>
+          <xsd:documentation>
+            This is the row index of the well, the origin is the top left corner of the plate
+            with the first row of wells being row zero. i.e top left is (0,0)
+            The combination of Row, Column has to be unique for each well in a plate.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="ExternalDescription" use="optional" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            A description of the externally defined identifier for this plate.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="ExternalIdentifier" use="optional" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            The ExternalIdentifier attribute may contain a reference to an external database.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="Type" use="optional" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            A human readable identifier for the screening status.
+            e.g. empty, positive control, negative control, control, experimental, etc.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="Color" use="optional" type="Color" default="-1">
+        <xsd:annotation>
+          <xsd:documentation>
+            A marker color used to highlight the well - encoded as RGBA
+            The default value "-1" is #FFFFFFFF so solid white (it is a signed 32 bit value)
+            NOTE: Prior to the 2012-06 schema the default value was incorrect and produced a transparent red not solid white.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:simpleType name="WellID">
+    <xsd:restriction base="LSID">
+      <xsd:pattern value="(urn:lsid:([\w\-\.]+\.[\w\-\.]+)+:Well:\S+)|(Well:\S+)"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:element name="WellSample"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:appinfo><xsdfu xmlns=""><plural>WellSamples</plural></xsdfu></xsd:appinfo>
+      <xsd:documentation>
+        WellSample is an individual image that has been captured within a Well.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="ImageRef" minOccurs="0" maxOccurs="1">
+          <xsd:annotation>
+            <xsd:appinfo><xsdfu xmlns=""><injected/></xsdfu></xsd:appinfo>
+            <xsd:documentation>
+              This is the main link to the core Image element
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+      </xsd:sequence>
+      <xsd:attribute name="ID" use="required" type="WellSampleID"/>
+      <xsd:attribute name="PositionX" use="optional" type="xsd:float">
+        <xsd:annotation>
+          <xsd:documentation>
+            The X position of the field (image) within the well relative to
+            the well origin defined on the Plate. Units are set by PositionXUnit.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="PositionXUnit" use="optional" default="reference frame" type="UnitsLength">
+        <xsd:annotation>
+          <xsd:documentation>The units of the position in X - default:reference frame.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="PositionY" use="optional" type="xsd:float">
+        <xsd:annotation>
+          <xsd:documentation>
+            The Y position of the field (image) within the well relative to
+            the well origin defined on the Plate. Units are set by PositionYUnit.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="PositionYUnit" use="optional" default="reference frame" type="UnitsLength">
+        <xsd:annotation>
+          <xsd:documentation>The units of the position in Y - default:reference frame.</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="Timepoint" use="optional" type="xsd:dateTime">
+        <xsd:annotation>
+          <xsd:documentation>
+            The time-point at which the image started to be collected
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="Index" use="required" type="NonNegativeInt">
+        <xsd:annotation>
+          <xsd:documentation>
+            This records the order of the well samples. Each
+            index should be unique for a given plate but they do not
+            have to be sequential, there may be gaps if part of the
+            dataset is missing. In the user interface the displayed
+            value of the index will be calculated modulo the number
+            of PlateAcquisitions for the plate.
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:simpleType name="WellSampleID">
+    <xsd:restriction base="LSID">
+      <xsd:pattern value="(urn:lsid:([\w\-\.]+\.[\w\-\.]+)+:WellSample:\S+)|(WellSample:\S+)"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:element name="WellSampleRef"> <!-- top level definition -->
+    <xsd:annotation>
+      <xsd:documentation>
+        The WellSampleRef element is a reference to a WellSample element.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="Reference">
+          <xsd:attribute name="ID" use="required" type="WellSampleID"/>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+
+</xsd:schema>

--- a/src/ingest_validation_tests/qptiff_channel_validator.py
+++ b/src/ingest_validation_tests/qptiff_channel_validator.py
@@ -288,7 +288,9 @@ class Engine:
     def __init__(self):
         self.check_dependencies()
 
-    def __call__(self, data_path: Path, file_dict: dict[str, Path], tmp_dir: Path) -> str | None:
+    def __call__(
+        self, data_path: Path | int, file_dict: dict[str, Path], tmp_dir: Path
+    ) -> str | None:
         """
         Check that channels in channel_id column of qptiff.channels.csv
         match channels in accompanying OME-XML file (generated from QPTIFF).
@@ -316,21 +318,29 @@ class Engine:
         channels_list.sort()
         return set([str(channel) for channel in channels_list])
 
-    def get_qptiff_channels(self, data_path: Path, qptiff_path: Path):
+    def get_qptiff_channels(self, data_path: Path | int, qptiff_path: Path):
         # get OME-XML
         ome_xml_path = self.extract_ome_xml(data_path, qptiff_path)
         try:
             return self.get_ome_xml_channels(ome_xml_path)
         except Exception as e:
-            raise Exception(f"Error with {get_rel_filename_str(data_path, qptiff_path)}: {e}")
+            if isinstance(data_path, Path):
+                data_desc = get_rel_filename_str(data_path, qptiff_path)
+            else:
+                data_desc = f"data row {data_path}"
+            raise Exception(f"Error with {data_desc}: {e}")
 
-    def extract_ome_xml(self, data_path: Path, qptiff_path: Path) -> Path:
+    def extract_ome_xml(self, data_path: Path | int, qptiff_path) -> Path:
         """
         The bioformats2raw params (except for no-tiles) are borrowed from the
         phenocycler pipeline (v1.4.8); major changes to how QPTIFFs are converted
         in the pipeline may desync this validation.
         """
-        output_dirname = f"{data_path.stem}_{qptiff_path.stem}_converted"
+        if isinstance(data_path, Path):
+            prefix = data_path.stem
+        else:
+            prefix = str(data_path)
+        output_dirname = f"{prefix}_{qptiff_path.stem}_converted"
         ome_xml_path = Path(self.tmp_dir / output_dirname / "OME/METADATA.ome.xml")
         if Path(self.tmp_dir / output_dirname).exists():
             if ome_xml_path.exists():

--- a/src/ingest_validation_tests/validator.py
+++ b/src/ingest_validation_tests/validator.py
@@ -137,7 +137,7 @@ class Validator:
 def check_ome_tiff_file(file: str | Path) -> xmlschema.XmlDocument:
     try:
         with tifffile.TiffFile(file) as tf:
-            xml_document = xmlschema.XmlDocument(tf.ome_metadata)  # type: ignore
+            xml_document = xmlschema.XmlDocument(tf.ome_metadata, schema=Path(__file__).resolve().parent / "ome_tiff_schemas/2016-06_ome.xsd")  # type: ignore
             if xml_document.schema and not xml_document.schema.is_valid(xml_document):
                 raise Exception(f"{file} is not a valid OME.TIFF file: schema not valid")
             elif not xml_document.schema:

--- a/src/ingest_validation_tests/validator.py
+++ b/src/ingest_validation_tests/validator.py
@@ -222,7 +222,12 @@ def validation_class_iter() -> list[Validator]:
     return sorted_classes
 
 
-def get_rel_filename_str(comparison_path: Path, filename: Path) -> str:
+def get_rel_filename_str(comparison_path: Path | int, filename: Path) -> str:
+    """
+    In the case of shared uploads, comparison_path may be an int (row number).
+    """
+    if isinstance(comparison_path, int):
+        return str(filename)
     try:
         return str(filename.relative_to(comparison_path.parent))
     except Exception:

--- a/tests/test_ome_tiff_field_validator.py
+++ b/tests/test_ome_tiff_field_validator.py
@@ -21,7 +21,7 @@ class TestOmeTiffFieldValidator(TestTiffValidators):
             (
                 "test_data/codex_tree_ometiff_bad.zip",
                 [
-                    ".*/codex_tree_ometiff_bad/tubhiswt_C0_bad.ome.tif is not a valid OME.TIFF file: wrong type <class 'NoneType'> for 'source' attribute: an ElementTree object or an Element instance or a string containing XML data or an URL or a file-like object is required.",
+                    ".*/codex_tree_ometiff_bad/tubhiswt_C0_bad.ome.tif is not a valid OME.TIFF file: 'NoneType' object has no attribute 'getroot'",
                     ".*/codex_tree_ometiff_bad/sample1.ome.tif is not a valid OME.TIFF file per schema 'ome_tiff_field_schema_default.xsd': missing required attribute 'PhysicalSizeX'; missing required attribute 'PhysicalSizeY'",
                     ".*/codex_tree_ometiff_bad/sample2.ome.tif is not a valid OME.TIFF file per schema 'ome_tiff_field_schema_default.xsd': missing required attribute 'PhysicalSizeX'; missing required attribute 'PhysicalSizeY'",
                 ],


### PR DESCRIPTION
Bugfixes:
- Use local copy of `ome.xsd` schema to validate OME-XML. Bypasses intermittent errors from requesting schema from the web with `xmlschema`.
- Handle int `data_path` values introduced by #101

Includes upgrade to `xmlschema` that @sunset666 suggested that somehow didn't make it into #101 