### PR TITLE
SegMask Image Upates

### DIFF
--- a/src/ingest_validation_tests/segmentation_mask_imagesize_validation.py
+++ b/src/ingest_validation_tests/segmentation_mask_imagesize_validation.py
@@ -4,30 +4,33 @@ from tests_utils import GetParentData
 from validator import Validator, check_ome_tiff_file
 
 
-def get_ometiff_size(file) -> str | dict:
+def get_ometiff_sizes(file) -> str | list[dict]:
     try:
         try:
             xml_document = check_ome_tiff_file(file)
         except Exception as e:
             return str(e)
-        xml_image_data = (
-            xml_document.schema.to_dict(xml_document).get("Image")[0].get("Pixels")  # type: ignore | xmlschema.DecodeType causing issues
-        )
+        images = xml_document.schema.to_dict(xml_document).get("Image")  # type: ignore | xmlschema.DecodeType causing issues
     except Exception as e:
         return f"{file} is not a valid OME.TIFF file: {e}"
     try:
-        rst = {
-            "X": xml_image_data.get("@PhysicalSizeX"),
-            "XUnits": xml_image_data.get("@PhysicalSizeXUnit"),
-            "XPix": xml_image_data.get("@SizeX"),
-            "Y": xml_image_data.get("@PhysicalSizeY"),
-            "YUnits": xml_image_data.get("@PhysicalSizeYUnit"),
-            "YPix": xml_image_data.get("@SizeY"),
-            "Z": xml_image_data.get("@PhysicalSizeZ"),
-            "ZUnits": xml_image_data.get("@PhysicalSizeZUnit"),
-            "ZPix": xml_image_data.get("@SizeZ"),
-        }
-        return rst
+        sizes = []
+        for image in images:
+            xml_image_data = image.get("Pixels")
+            sizes.append(
+                {
+                    "X": xml_image_data.get("@PhysicalSizeX"),
+                    "XUnits": xml_image_data.get("@PhysicalSizeXUnit"),
+                    "XPix": xml_image_data.get("@SizeX"),
+                    "Y": xml_image_data.get("@PhysicalSizeY"),
+                    "YUnits": xml_image_data.get("@PhysicalSizeYUnit"),
+                    "YPix": xml_image_data.get("@SizeY"),
+                    "Z": xml_image_data.get("@PhysicalSizeZ"),
+                    "ZUnits": xml_image_data.get("@PhysicalSizeZUnit"),
+                    "ZPix": xml_image_data.get("@SizeZ"),
+                }
+            )
+        return sizes
     except Exception as excp:
         return f"{file} is not a valid OME.TIFF file: {excp}"
 
@@ -82,11 +85,13 @@ class ImageSizeValidator(Validator):
                     len(parent_filenames_to_test) == 1
                 ), f"Too many or too few files Base Images ({[self.rel_filename_str(path) for path in parent_filenames_to_test]})"
 
-                segmentation_mask_size = get_ometiff_size(filenames_to_test[0])
-                base_image_size = get_ometiff_size(parent_filenames_to_test[0])
-                assert (
-                    segmentation_mask_size == base_image_size
-                ), "Files and base image size do not match"
+                segmentation_mask_sizes = get_ometiff_sizes(filenames_to_test[0])
+                base_image_sizes = get_ometiff_sizes(parent_filenames_to_test[0])
+                assert not isinstance(segmentation_mask_sizes, str), segmentation_mask_sizes
+                assert not isinstance(base_image_sizes, str), base_image_sizes
+                assert any(
+                    mask_size in base_image_sizes for mask_size in segmentation_mask_sizes
+                ), "No segmentation mask image matches any base image size"
                 files_tested = True
 
             except AssertionError as e:

--- a/tests/test_segmentation_mask_imagesize_validator.py
+++ b/tests/test_segmentation_mask_imagesize_validator.py
@@ -6,6 +6,19 @@ from unittest.mock import patch
 import pandas as pd  # to parse metadata.tsv
 import pytest
 
+CROP512_SIZE = {
+    "X": 0.2520000043344001,
+    "XUnits": "µm",
+    "XPix": 512,
+    "Y": 0.2520000043344001,
+    "YUnits": "µm",
+    "YPix": 512,
+    "Z": None,
+    "ZUnits": "µm",
+    "ZPix": 1,
+}
+DIFFERENT_SIZE = {**CROP512_SIZE, "XPix": 400, "YPix": 400}
+
 
 @pytest.mark.parametrize(
     ("test_data_fname", "parent_data_fname", "msg_re_list", "assay_type"),
@@ -25,7 +38,7 @@ import pytest
         (
             "test_data/segmask_HBM787.DVDV.435_crop400.zip",
             "test_data/pas_HBM847.ZQZH.768_crop512.zip",
-            ["Files and base image size do not match"],
+            ["No segmentation mask image matches any base image size"],
             "segmentation mask",
         ),
         (
@@ -69,3 +82,38 @@ def test_segmentation_mask_imagesize_validator(
         assert (err_str is None and re_str is None) or re.match(
             re_str, err_str, flags=re.MULTILINE
         )
+
+
+@patch("tests_utils.GetParentData.get_path")
+@patch("segmentation_mask_imagesize_validation.get_ometiff_sizes")
+def test_multi_image_parent_match_passes(mock_get_sizes, mock_get_path, tmp_path):
+    """Parent OME-TIFF with multiple images: passes when any image matches mask."""
+    test_data_path = Path("test_data/segmask_HBM787.DVDV.435_crop512.zip")
+    parent_data_path = Path("test_data/pas_HBM847.ZQZH.768_crop512.zip")
+    tmp_seg_path = tmp_path / "segfile"
+    tmp_parent_path = tmp_path / "parent"
+    tmp_seg_path.mkdir(parents=True, exist_ok=True)
+    tmp_parent_path.mkdir(parents=True, exist_ok=True)
+    zipfile.ZipFile(test_data_path).extractall(tmp_seg_path)
+    zipfile.ZipFile(parent_data_path).extractall(tmp_parent_path)
+    mock_get_path.return_value = tmp_parent_path
+
+    mock_get_sizes.side_effect = lambda f: (
+        [CROP512_SIZE]
+        if "segmentation_masks" in str(f)
+        else [DIFFERENT_SIZE, CROP512_SIZE]
+    )
+
+    from segmentation_mask_imagesize_validation import ImageSizeValidator
+
+    tsv_path_l = list((tmp_seg_path / test_data_path.stem).glob("*metadata.tsv"))
+    assert len(tsv_path_l) == 1
+    recs_df = pd.read_csv(tsv_path_l[0], sep="\t")
+    validator = ImageSizeValidator(
+        tmp_seg_path / test_data_path.stem,
+        "segmentation mask",
+        schema_rows=recs_df.to_dict("records"),
+        coreuse=4,
+    )
+    errors = validator.collect_errors()[:]
+    assert errors == [None]


### PR DESCRIPTION
fix: Update to grab all of the image sizes in seg mask/parent image and then check if there are ANY matches.

This deals with issue #105 