### PR TITLE
QPTIFF updates

### DIFF
--- a/src/ingest_validation_tests/geojson_tiff_validator.py
+++ b/src/ingest_validation_tests/geojson_tiff_validator.py
@@ -1,14 +1,17 @@
 import json
+import os
+import re
 from functools import cached_property
 from pathlib import Path
 
 import tifffile
 from shapely.geometry import box, shape
-from validator import Validator, get_non_global_paths_by_row, ome_tiff_globs
-
-qptiff_glob = "**/*.[qQ][pP][tT][iI][fF][fF]"
-
-all_globs = ome_tiff_globs + [qptiff_glob]
+from validator import (
+    OME_TIFF_GLOBS,
+    QPTIFF_REGEX,
+    Validator,
+    get_non_global_paths_by_row,
+)
 
 
 class GeoJsonTiffValidator(Validator):
@@ -39,7 +42,7 @@ class GeoJsonTiffValidator(Validator):
             self.errors.extend(
                 self._check_tiff_counts(files_dict["ome_tiff"], files_dict["qptiff"])
             )
-            result = self._check_geojson_intersects_tiffs(files_dict["geojson"], tiff_files)
+            result = self._check_geojson_intersects_tiffs(files_dict["geojson"][0], tiff_files)
             if result is not None:
                 self.errors.append(result)
 
@@ -48,7 +51,7 @@ class GeoJsonTiffValidator(Validator):
     ####################
 
     @cached_property
-    def files_to_test(self) -> dict[Path | int, dict[str, Path | list[Path]]]:
+    def files_to_test(self) -> dict[int, dict[str, list[Path]]]:
         """
         For each data path, locate a single GeoJSON file and TIFF files.
         Returns:
@@ -68,18 +71,33 @@ class GeoJsonTiffValidator(Validator):
             ome_tiffs = list(
                 set(
                     f
-                    for glob_expr in ome_tiff_globs
+                    for glob_expr in OME_TIFF_GLOBS
                     for f in path.glob(glob_expr)
                     if not self._is_in_extras(f)
                 )
             )
-            qptiffs = list(set(f for f in path.glob(qptiff_glob) if not self._is_in_extras(f)))
+            qptiffs = self._get_qptiffs_for_data_path(path)
             files_to_test[path] = {
-                "geojson": geojson_file,
+                "geojson": [geojson_file],
                 "ome_tiff": ome_tiffs,
                 "qptiff": qptiffs,
             }
         return files_to_test
+
+    def _get_qptiffs_for_data_path(self, data_path: Path) -> list[Path]:
+        """
+        Exclude any QPTIFF files in extras/ or with .raw/raw. in the filename.
+        """
+        qptiffs = []
+        for path, _, files in os.walk(data_path):
+            qptiffs.extend(
+                [
+                    Path(path, name)
+                    for name in files
+                    if re.search(QPTIFF_REGEX, name) and not self._is_in_extras(Path(path, name))
+                ]
+            )
+        return qptiffs
 
     def _get_geojson_file(self, path: Path) -> Path | None:
         files = list(path.glob("**/*.geojson"))
@@ -114,15 +132,12 @@ class GeoJsonTiffValidator(Validator):
             global_ome_tiffs = list(
                 set(
                     f
-                    for glob_expr in ome_tiff_globs
+                    for glob_expr in OME_TIFF_GLOBS
                     for f in global_path.glob(glob_expr)
                     if not self._is_in_extras(f)
                 )
             )
-            global_qptiffs = list(
-                set(f for f in global_path.glob(qptiff_glob) if not self._is_in_extras(f))
-            )
-
+            global_qptiffs = self._get_qptiffs_for_data_path(global_path)
         all_files: dict[int, dict[str, Path | list[Path]]] = {}
         for row_num, row_paths in non_global_paths.items():
             geojson_files = [p for p in row_paths if p.suffix.lower() == ".geojson"]
@@ -184,7 +199,7 @@ class GeoJsonTiffValidator(Validator):
     def _get_tiff_bounds(self, path: Path) -> tuple[int, int] | str:
         try:
             with tifffile.TiffFile(path) as tf:
-                series = tf.series[0]
+                series = tf.series[0]  # type: ignore
                 axes = series.axes.upper()
                 shape_ = series.shape
                 if "Y" not in axes or "X" not in axes:
@@ -223,7 +238,7 @@ class GeoJsonTiffValidator(Validator):
                 geom = shape(feature["geometry"])
             except Exception as e:
                 return f"{geojson_path}: invalid geometry: {e}"
-            for tiff_path, (width, height) in tiff_dims:
+            for _, (width, height) in tiff_dims:
                 tiff_box = box(0, 0, width, height)
                 if tiff_box.intersects(geom):
                     return None  # at least one intersection found

--- a/src/ingest_validation_tests/ome_tiff_field_validator.py
+++ b/src/ingest_validation_tests/ome_tiff_field_validator.py
@@ -5,7 +5,7 @@ from multiprocessing import Pool
 from pathlib import Path
 
 import xmlschema
-from validator import Validator, check_ome_tiff_file, ome_tiff_globs
+from validator import OME_TIFF_GLOBS, Validator, check_ome_tiff_file
 
 
 class OmeTiffFieldValidator(Validator):
@@ -58,7 +58,7 @@ class OmeTiffFieldValidator(Validator):
             return [str(e)]
 
         filenames_to_test = []
-        for glob_expr in ome_tiff_globs:
+        for glob_expr in OME_TIFF_GLOBS:
             for path in self.paths:
                 for file in path.glob(glob_expr):
                     filenames_to_test.append(file)

--- a/src/ingest_validation_tests/qptiff_channel_validator.py
+++ b/src/ingest_validation_tests/qptiff_channel_validator.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 import xmlschema
 from validator import (
     BASE_OME_XML_SCHEMA,
+    QPTIFF_REGEX,
     Validator,
     csv_to_df,
     get_non_global_paths_by_row,
@@ -59,6 +60,7 @@ class QpTiffChannelValidator(Validator):
             assert (
                 self.files_to_test
             ), f"Could not find qptiff.channels.csv and associated QPTIFF files (required for {self.assay_type})."
+            self._log(f"Files to test: {self.files_to_test}")
         except Exception as e:
             if not self.errors:
                 self.errors.append(f"Error retrieving files to test: {e}")
@@ -91,8 +93,11 @@ class QpTiffChannelValidator(Validator):
             if self.shared_upload:
                 files_to_test.update(self._get_shared_upload_file_pairs(path.parent))
                 break
-            channel_csv = self._get_file_path(path / "lab_processed/images", ".channels.csv")
-            qptiff_file = self._get_file_path(path / "raw/images", ".qptiff")
+            channel_csv = self._get_file_path(path / "lab_processed/images", "qptiff.channels.csv")
+            qptiff_file = self._get_file_path(
+                path / "raw/images",
+                QPTIFF_REGEX,
+            )
             if not (channel_csv and qptiff_file):
                 continue
             files_to_test[path] = {"csv": channel_csv, "qptiff": qptiff_file}
@@ -113,7 +118,11 @@ class QpTiffChannelValidator(Validator):
         try:
             # get global values
             global_files = self._shared_upload_get_global_files(base_path)
-            # retrieve non_global files identified in metadata.tsv
+            # if both required files are in global, they will be used for all datasets;
+            # return to prevent looping through every dataset
+            if global_files["csv"] and global_files["qptiff"]:
+                return {0: global_files}  # type: ignore
+            # otherwise, retrieve non_global files identified in metadata.tsv
             non_global_paths = get_non_global_paths_by_row(self.schema_rows, base_path)
         except Exception as e:
             # if too many global files or any expected non_global path not found, return
@@ -184,7 +193,7 @@ class QpTiffChannelValidator(Validator):
                 f"Found {len(files_list)} {file_type}s ({paths_str}) for dataset in row {row} in shared upload."
             )
 
-    def _get_file_path(self, parent_path: Path, extension: str) -> Path | None:
+    def _get_file_path(self, parent_path: Path, regex_str: str) -> Path | None:
         if not parent_path.exists():
             self.errors.append(
                 f"Did not find expected directory {self.rel_filename_str(parent_path)}"
@@ -192,11 +201,11 @@ class QpTiffChannelValidator(Validator):
             return
         files = []
         for filename in parent_path.iterdir():
-            if str(filename).lower().endswith(extension):
+            if re.search(re.compile(regex_str), str(filename).lower()):
                 files.append(filename)
         if len(files) != 1:
             self.errors.append(
-                f"Found {len(files)} {extension} files in {self.rel_filename_str(parent_path)} directory."
+                f"Found {len(files)} files matching '{regex_str}' in {self.rel_filename_str(parent_path)} directory."
             )
             return
         return files[0]

--- a/src/ingest_validation_tests/validator.py
+++ b/src/ingest_validation_tests/validator.py
@@ -11,6 +11,11 @@ import tifffile
 import xmlschema
 
 BASE_OME_XML_SCHEMA = Path(__file__).resolve().parent / "ome_tiff_schemas/2016-06_ome.xsd"
+OME_TIFF_GLOBS = [
+    "**/*.[oO][mM][eE].[tT][iI][fF]",
+    "**/*.[oO][mM][eE].[tT][iI][fF][fF]",
+]
+QPTIFF_REGEX = ".*(?<!\\.raw|raw\\.)qptiff$"
 
 
 class Validator:
@@ -141,7 +146,7 @@ class Validator:
         raise Exception("no uuid was found in the path to the current working directory")
 
 
-def get_non_global_paths_by_row(rows: list[dict], base_path: Path) -> dict[str | int, str]:
+def get_non_global_paths_by_row(rows: list[dict], base_path: Path) -> dict[int, list[Path]]:
     """
     Create dict of non-global paths by row for a shared upload.
     {<row_index_0>: [<path_1>, <path_2>], <row_index_1>: [<path_3>, <path_4>]}
@@ -187,12 +192,6 @@ def check_ome_tiff_file(file: str | Path) -> xmlschema.XmlDocument:
         print(f"{file} is not a valid OME.TIFF file: {excp}")
         raise Exception(f"{file} is not a valid OME.TIFF file: {excp}")
     return xml_document
-
-
-ome_tiff_globs = [
-    "**/*.[oO][mM][eE].[tT][iI][fF]",
-    "**/*.[oO][mM][eE].[tT][iI][fF][fF]",
-]
 
 
 def validation_class_iter() -> list[Validator]:

--- a/tests/test_geojson_tiff_validator.py
+++ b/tests/test_geojson_tiff_validator.py
@@ -67,8 +67,8 @@ class TestGeoJsonTiffValidator(TestTiffValidators):
     def test_get_file_path(self, tmp_path):
         good_filenames = [
             PurePosixPath(tmp_path / "test.qptiff"),
-            PurePosixPath(tmp_path / "test_dir/test.qptiff"),
             PurePosixPath(tmp_path / "test_dir/extras.qptiff"),
+            PurePosixPath(tmp_path / "test_dir/test.qptiff"),
         ]
         bad_filenames = [
             PurePosixPath(tmp_path / "test.qptiff.raw"),
@@ -84,5 +84,4 @@ class TestGeoJsonTiffValidator(TestTiffValidators):
             with open(file, "w", newline="") as mock_file:
                 mock_file.write("should be ignored")
         validator = GeoJsonTiffValidator([tmp_path], "")
-        assert validator._get_qptiffs_for_data_path(tmp_path) == good_filenames
-
+        assert sorted(validator._get_qptiffs_for_data_path(tmp_path)) == good_filenames

--- a/tests/test_geojson_tiff_validator.py
+++ b/tests/test_geojson_tiff_validator.py
@@ -1,8 +1,11 @@
 import zipfile
-from pathlib import Path
+from pathlib import Path, PurePosixPath
+from unittest.mock import MagicMock, patch
 
 import pytest
 from test_tiff_validators_base_class import TestTiffValidators
+
+from src.ingest_validation_tests.geojson_tiff_validator import GeoJsonTiffValidator
 
 
 class TestGeoJsonTiffValidator(TestTiffValidators):
@@ -53,7 +56,6 @@ class TestGeoJsonTiffValidator(TestTiffValidators):
         ),
     )
     def test_geojson_tiff_validator(self, test_data_fname, msg_re_list, assay_type, tmp_path):
-        from geojson_tiff_validator import GeoJsonTiffValidator
 
         test_data_path = Path(test_data_fname)
         zfile = zipfile.ZipFile(test_data_path)
@@ -61,3 +63,26 @@ class TestGeoJsonTiffValidator(TestTiffValidators):
         validator = GeoJsonTiffValidator(tmp_path / test_data_path.stem, assay_type)
         errors = validator.collect_errors()[:]
         self.check_errors(msg_re_list, errors)
+
+    def test_get_file_path(self, tmp_path):
+        good_filenames = [
+            PurePosixPath(tmp_path / "test.qptiff"),
+            PurePosixPath(tmp_path / "test_dir/test.qptiff"),
+            PurePosixPath(tmp_path / "test_dir/extras.qptiff"),
+        ]
+        bad_filenames = [
+            PurePosixPath(tmp_path / "test.qptiff.raw"),
+            PurePosixPath(tmp_path / "test.raw.qptiff"),
+            PurePosixPath(tmp_path / "test_dir/test.qptiff.raw"),
+            PurePosixPath(tmp_path / "test_dir/test.raw.qptiff"),
+            PurePosixPath(tmp_path / "test_dir/extras/test.qptiff"),
+            PurePosixPath(tmp_path / "extras/test_dir/test.qptiff"),
+        ]
+        Path(tmp_path / "test_dir/extras").mkdir(parents=True)
+        Path(tmp_path / "extras/test_dir").mkdir(parents=True)
+        for file in [*good_filenames, *bad_filenames]:
+            with open(file, "w", newline="") as mock_file:
+                mock_file.write("should be ignored")
+        validator = GeoJsonTiffValidator([tmp_path], "")
+        assert validator._get_qptiffs_for_data_path(tmp_path) == good_filenames
+

--- a/tests/test_qptiff_channel_validator.py
+++ b/tests/test_qptiff_channel_validator.py
@@ -2,6 +2,7 @@ import csv
 import os
 import zipfile
 from pathlib import Path
+from typing import Literal
 from unittest.mock import Mock
 
 import pytest
@@ -10,6 +11,8 @@ from qptiff_channel_validator import (  # type: ignore
     QpTiffChannelComparisonValidator,
     QpTiffChannelValidator,
 )
+
+from src.ingest_validation_tests.validator import QPTIFF_REGEX
 
 
 class TestQpTiffChannelCsv:
@@ -96,7 +99,7 @@ class TestQpTiffChannelCsv:
         errors = validator.collect_errors()[:]
         errors.sort()
         for err in [
-            "Found 0 .channels.csv files in test_missing_channels_csv0/lab_processed/images directory.",
+            "Found 0 files matching 'qptiff.channels.csv' in test_missing_channels_csv0/lab_processed/images directory.",
         ]:
             assert err in errors
 
@@ -150,23 +153,15 @@ class TestQpTiffChannelCsv:
         for error in msg_re_list:
             assert error in validator.errors
 
-    #######################
-    # Setup shared upload #
-    #######################
+    ################
+    # Create files #
+    ################
 
     test_csv_filename = "test.qptiff.channels.csv"
     test_qptiff_filename = "test.qptiff"
 
-    def _create_shared_upload_dirs(self, tmp_dir):
-        Path(tmp_dir / "global/lab_processed/images").mkdir(parents=True)
-        Path(tmp_dir / "global/raw/images").mkdir(parents=True)
-        Path(tmp_dir / "non_global/lab_processed/images").mkdir(parents=True)
-        Path(tmp_dir / "non_global/raw/images").mkdir(parents=True)
-
-    def _create_channels_csv_good(self, output_dir: Path, filename: str | None = None):
-        if not filename:
-            filename = self.test_csv_filename
-        with open(Path(output_dir / filename), "w", newline="") as mock_csv:
+    def _create_channels_csv_good(self, output_path: Path):
+        with open(Path(output_path), "w", newline="") as mock_csv:
             writer = csv.writer(mock_csv)
             writer.writerows(
                 [
@@ -179,16 +174,83 @@ class TestQpTiffChannelCsv:
                 ]
             )
 
-    def _create_qptiff(self, output_dir: Path):
-        with open(Path(output_dir / self.test_qptiff_filename), "w", newline="") as mock_qptiff:
+    def _create_qptiff(self, output_path: Path):
+        with open(Path(output_path), "w", newline="") as mock_qptiff:
             mock_qptiff.write("good")
 
+    ######################
+    # Test files_to_test #
+    ######################
+
+    def test_exclude_raw_qptiffs(self, tmp_path):
+        Path(tmp_path / "lab_processed/images").mkdir(parents=True)
+        Path(tmp_path / "raw/images").mkdir(parents=True)
+        self._create_channels_csv_good(
+            Path(tmp_path / f"lab_processed/images/{self.test_csv_filename}")
+        )
+        self._create_qptiff(Path(tmp_path / f"raw/images/{self.test_qptiff_filename}"))
+        with open(
+            Path(tmp_path / "raw/images/test.raw.qptiff"), "w", newline=""
+        ) as mock_raw_qptiff:
+            mock_raw_qptiff.write("should be excluded")
+        validator = QpTiffChannelValidator(
+            [tmp_path],
+            "phenocycler",
+            schema_rows=[],
+        )
+        validator.files_to_test
+        # raw.qptiff file exists alongside qptiff
+        assert Path(tmp_path / "raw/images/test.raw.qptiff").exists()
+        assert Path(tmp_path / f"raw/images/{self.test_qptiff_filename}").exists()
+        # files_to_test for path has expected number of keys
+        assert len(validator.files_to_test[Path(tmp_path)]) == 2
+        # files_to_test for path has a value for "csv"
+        assert validator.files_to_test[Path(tmp_path)]["csv"]
+        # files_to_test for path includes the qptiff file and not the raw.qptiff
+        assert validator.files_to_test[Path(tmp_path)]["qptiff"] == Path(
+            tmp_path / f"raw/images/{self.test_qptiff_filename}"
+        )
+
+    def test_get_file_path(self, tmp_path):
+        """
+        Exclude raw.qptiff and qptiff.raw.
+        Exclude qptiffs in subdirectories.
+        """
+        good_filename = "test.qptiff"
+        bad_filenames = [
+            "test.qptiff.raw",
+            "test.raw.qptiff",
+            "test_dir/test.qptiff",
+            "test_dir/test.qptiff.raw",
+            "test_dir/test.raw.qptiff",
+        ]
+        Path(tmp_path / "test_dir").mkdir()
+        for file in [good_filename, *bad_filenames]:
+            with open(Path(tmp_path / file), "w", newline="") as mock_file:
+                mock_file.write("should be ignored")
+        validator = QpTiffChannelValidator([tmp_path], "phenocycler")
+        assert validator._get_file_path(tmp_path, QPTIFF_REGEX) == tmp_path / good_filename
+
+    #######################
+    # Setup shared upload #
+    #######################
+
+    def _create_shared_upload_dirs(self, tmp_dir):
+        Path(tmp_dir / "global/lab_processed/images").mkdir(parents=True)
+        Path(tmp_dir / "global/raw/images").mkdir(parents=True)
+        Path(tmp_dir / "non_global/lab_processed/images").mkdir(parents=True)
+        Path(tmp_dir / "non_global/raw/images").mkdir(parents=True)
+
     def _create_shared_upload_validator(
-        self, tmp_path: Path, data_row_to_non_global: dict[int, str]
+        self, tmp_path: Path, non_global_file_list: dict[int, list[str]]
     ) -> QpTiffChannelValidator:
         rows = []
-        for data_path, non_global_files in data_row_to_non_global.items():
-            rows.append({"data_path": data_path, "non_global_files": non_global_files})
+        for non_global_files in non_global_file_list.values():
+            rows.append({"non_global_files": "; ".join(non_global_files)})
+            for file in non_global_files:
+                if not Path(file).exists():
+                    with open(Path(tmp_path / "non_global" / file), "w", newline="") as mock_file:
+                        mock_file.write("should be ignored")
         return QpTiffChannelValidator(
             [Path(tmp_path / "global"), Path(tmp_path / "non_global")],
             "phenocycler",
@@ -196,24 +258,49 @@ class TestQpTiffChannelCsv:
         )
 
     def _set_up_shared_upload_test_dirs(
-        self, tmp_path: Path, csv_in_global: bool, qptiff_in_global: bool
+        self,
+        tmp_path: Path,
+        global_files: list[str] = [],
+        non_global_files: dict[int, list[str]] = {},
     ):
         self._create_shared_upload_dirs(tmp_path)
-        csv_path = (
-            "global/lab_processed/images" if csv_in_global else "non_global/lab_processed/images"
-        )
-        qptiff_path = "global/raw/images" if qptiff_in_global else "non_global/raw/images"
-        self._create_channels_csv_good(Path(tmp_path / csv_path))
-        self._create_qptiff(Path(tmp_path / qptiff_path))
+        non_global_file_list = []
+        for ng_file_list in non_global_files.values():
+            non_global_file_list.extend(ng_file_list)
+        for dir, file_list in {"global": global_files, "non_global": non_global_file_list}.items():
+            if not file_list:
+                continue
+            for file_path in file_list:
+                self.create_test_file(tmp_path, dir, file_path)
 
-    def _set_up_shared_upload_test(self, tmp_path, csv_in_global: bool, qptiff_in_global: bool):
-        self._set_up_shared_upload_test_dirs(tmp_path, csv_in_global, qptiff_in_global)
-        non_global_files = []
-        if not csv_in_global:
-            non_global_files.append(f"./lab_processed/images/{self.test_csv_filename}")
-        if not qptiff_in_global:
-            non_global_files.append(f"./raw/images/{self.test_qptiff_filename}")
-        return self._create_shared_upload_validator(tmp_path, {0: "; ".join(non_global_files)})
+    def create_test_file(self, tmp_dir, dir, file_path):
+        if file_path.endswith("csv"):
+            self._create_channels_csv_good(Path(tmp_dir / dir / file_path))
+        elif file_path.endswith("qptiff"):
+            self._create_qptiff(Path(tmp_dir / dir / file_path))
+
+    def get_csv_path(
+        self, tmp_dir, dir: Literal["global"] | Literal["non_global"], filename: str | None = None
+    ):
+        if not filename:
+            filename = self.test_csv_filename
+        return Path(f"{tmp_dir}/{dir}/lab_processed/images/{filename}")
+
+    def get_qptiff_path(
+        self, tmp_dir, dir: Literal["global"] | Literal["non_global"], filename: str | None = None
+    ):
+        if not filename:
+            filename = self.test_qptiff_filename
+        return Path(f"{tmp_dir}/{dir}/raw/images/{filename}")
+
+    def _set_up_shared_upload_test(
+        self,
+        tmp_path,
+        global_files: list[str] = [],
+        non_global_files: dict[int, list[str]] = {},
+    ):
+        self._set_up_shared_upload_test_dirs(tmp_path, global_files, non_global_files)
+        return self._create_shared_upload_validator(tmp_path, non_global_files)
 
     ######################
     # Test shared upload #
@@ -221,7 +308,17 @@ class TestQpTiffChannelCsv:
 
     def test_shared_upload_good_all_in_non_global(self, tmp_path):
         validator = self._set_up_shared_upload_test(
-            tmp_path, csv_in_global=False, qptiff_in_global=False
+            tmp_path,
+            non_global_files={
+                0: [
+                    f"raw/images/{self.test_qptiff_filename}",
+                    f"lab_processed/images/{self.test_csv_filename}",
+                ],
+                1: [
+                    f"raw/images/2nd_{self.test_qptiff_filename}",
+                    f"lab_processed/images/2nd_{self.test_csv_filename}",
+                ],
+            },
         )
         assert validator.files_to_test == {
             0: {
@@ -229,41 +326,77 @@ class TestQpTiffChannelCsv:
                     f"{tmp_path}/non_global/lab_processed/images/{self.test_csv_filename}"
                 ),
                 "qptiff": Path(f"{tmp_path}/non_global/raw/images/{self.test_qptiff_filename}"),
-            }
+            },
+            1: {
+                "csv": Path(
+                    f"{tmp_path}/non_global/lab_processed/images/2nd_{self.test_csv_filename}"
+                ),
+                "qptiff": Path(
+                    f"{tmp_path}/non_global/raw/images/2nd_{self.test_qptiff_filename}"
+                ),
+            },
         }
 
-    def test_shared_upload_good_mixed1(self, tmp_path):
+    def test_shared_upload_good_mixed_1(self, tmp_path):
+        csv_path = self.get_csv_path(tmp_path, "global")
         validator = self._set_up_shared_upload_test(
-            tmp_path, csv_in_global=True, qptiff_in_global=False
+            tmp_path,
+            global_files=[str(csv_path)],
+            non_global_files={
+                0: [f"raw/images/{self.test_qptiff_filename}"],
+                1: [f"raw/images/2nd_{self.test_qptiff_filename}"],
+            },
         )
         assert validator.files_to_test == {
             0: {
-                "csv": Path(f"{tmp_path}/global/lab_processed/images/{self.test_csv_filename}"),
-                "qptiff": Path(f"{tmp_path}/non_global/raw/images/{self.test_qptiff_filename}"),
-            }
+                "csv": csv_path,
+                "qptiff": self.get_qptiff_path(tmp_path, "non_global"),
+            },
+            1: {
+                "csv": csv_path,
+                "qptiff": self.get_qptiff_path(
+                    tmp_path, "non_global", f"2nd_{self.test_qptiff_filename}"
+                ),
+            },
         }
 
     def test_shared_upload_good_mixed_2(self, tmp_path):
         validator = self._set_up_shared_upload_test(
-            tmp_path, csv_in_global=False, qptiff_in_global=True
+            tmp_path,
+            global_files=[str(self.get_qptiff_path(tmp_path, "global"))],
+            non_global_files={
+                0: [f"lab_processed/images/{self.test_csv_filename}"],
+                1: [f"lab_processed/images/2nd_{self.test_csv_filename}"],
+            },
         )
+        shared_qptiff_path = self.get_qptiff_path(tmp_path, "global", self.test_qptiff_filename)
         assert validator.files_to_test == {
             0: {
-                "csv": Path(
-                    f"{tmp_path}/non_global/lab_processed/images/{self.test_csv_filename}"
-                ),
-                "qptiff": Path(f"{tmp_path}/global/raw/images/{self.test_qptiff_filename}"),
-            }
+                "csv": Path(self.get_csv_path(tmp_path, "non_global")),
+                "qptiff": shared_qptiff_path,
+            },
+            1: {
+                "csv": self.get_csv_path(tmp_path, "non_global", f"2nd_{self.test_csv_filename}"),
+                "qptiff": shared_qptiff_path,
+            },
         }
 
     def test_shared_upload_good_all_in_global(self, tmp_path):
+        """
+        Only want one key in files_to_test if both files are in global to prevent
+        multiple identical loops.
+        """
+        csv_file = self.get_csv_path(tmp_path, "global")
+        qptiff_file = self.get_qptiff_path(tmp_path, "global")
         validator = self._set_up_shared_upload_test(
-            tmp_path, csv_in_global=True, qptiff_in_global=True
+            tmp_path,
+            global_files=[str(csv_file), str(qptiff_file)],
+            non_global_files={0: ["file1.txt", "file2.ome.tiff"], 1: ["file2.txt"]},
         )
         assert validator.files_to_test == {
             0: {
-                "csv": Path(f"{tmp_path}/global/lab_processed/images/{self.test_csv_filename}"),
-                "qptiff": Path(f"{tmp_path}/global/raw/images/{self.test_qptiff_filename}"),
+                "csv": csv_file,
+                "qptiff": qptiff_file,
             }
         }
 
@@ -271,64 +404,68 @@ class TestQpTiffChannelCsv:
         """
         Detect missing file between non_global and global dirs
         """
+        csv_file = self.get_csv_path(tmp_path, "global")
+        qptiff_file = self.get_qptiff_path(tmp_path, "global")
         validator = self._set_up_shared_upload_test(
-            tmp_path, csv_in_global=True, qptiff_in_global=True
+            tmp_path,
+            global_files=[str(csv_file), str(qptiff_file)],
+            non_global_files={0: ["file1.txt"], 1: ["file2.txt"]},
         )
         os.remove(Path(tmp_path / f"global/lab_processed/images/{self.test_csv_filename}"))
         validator.files_to_test
-        assert validator.errors == ["Unable to find csv file for dataset row 0 in shared upload."]
+        assert validator.errors == [
+            "Unable to find csv file for dataset row 0 in shared upload.",
+            "Unable to find csv file for dataset row 1 in shared upload.",
+        ]
 
     def test_shared_upload_bad_file_missing_in_tsv(self, tmp_path):
         """
         File in non_global missing from metadata.tsv > non_global_files
         """
-        self._set_up_shared_upload_test(tmp_path, csv_in_global=False, qptiff_in_global=False)
+        self._set_up_shared_upload_test(
+            tmp_path,
+            non_global_files={
+                0: [
+                    f"raw/images/{self.test_qptiff_filename}",
+                    f"lab_processed/images/{self.test_csv_filename}",
+                ],
+                1: [
+                    f"raw/images/2nd_{self.test_qptiff_filename}",
+                    f"lab_processed/images/2nd_{self.test_csv_filename}",
+                ],
+            },
+        )
         validator = QpTiffChannelValidator(
             [Path(tmp_path / "global"), Path(tmp_path / "non_global")],
             "phenocycler",
             schema_rows=[
                 {
                     "non_global_files": f"./lab_processed/images/{self.test_csv_filename}",
-                }
-            ],
-        )
-        validator.files_to_test
-        assert validator.errors == [
-            "Unable to find qptiff file for dataset row 0 in shared upload."
-        ]
-
-    def test_shared_upload_bad_extra_file_in_tsv(self, tmp_path):
-        """
-        File in metadata.tsv > non_global_files is actually in global
-        """
-        self._set_up_shared_upload_test(tmp_path, csv_in_global=True, qptiff_in_global=True)
-        validator = QpTiffChannelValidator(
-            [Path(tmp_path / "global"), Path(tmp_path / "non_global")],
-            "phenocycler",
-            schema_rows=[
+                },
                 {
-                    "non_global_files": f"./lab_processed/images/{self.test_csv_filename}",
-                }
+                    "non_global_files": f"./lab_processed/images/2nd_{self.test_csv_filename}",
+                },
             ],
         )
         validator.files_to_test
         assert validator.errors == [
-            "Files listed in non_global_files field do not exist: test_shared_upload_bad_extra_f0/non_global/lab_processed/images/test.qptiff.channels.csv"
+            "Unable to find qptiff file for dataset row 0 in shared upload.",
+            "Unable to find qptiff file for dataset row 1 in shared upload.",
         ]
 
     def test_shared_upload_bad_multiple_global(self, tmp_path):
         """
         Multiple channels.csv files found in global
         """
-        self._set_up_shared_upload_test(tmp_path, csv_in_global=True, qptiff_in_global=True)
-        self._create_channels_csv_good(
-            Path(tmp_path / "global/lab_processed/images/"),
-            filename=f"2nd_{self.test_csv_filename}",
+        csv_file = self.get_csv_path(tmp_path, "global")
+        qptiff_file = self.get_qptiff_path(tmp_path, "global")
+        validator = self._set_up_shared_upload_test(
+            tmp_path,
+            global_files=[str(csv_file), str(qptiff_file)],
+            non_global_files={0: ["file1.txt"], 1: ["file2.txt"]},
         )
-        validator = QpTiffChannelValidator(
-            [Path(tmp_path / "global"), Path(tmp_path / "non_global")],
-            "phenocycler",
-            schema_rows=[{}],
+        self._create_channels_csv_good(
+            Path(tmp_path / f"global/lab_processed/images/2nd_{self.test_csv_filename}"),
         )
         validator.files_to_test
         assert validator.errors == [
@@ -340,20 +477,20 @@ class TestQpTiffChannelCsv:
         One file pair is fine, the other is missing a file.
         Make sure the good pair is validated and the error is logged for the bad pair.
         """
-        self._set_up_shared_upload_test_dirs(tmp_path, csv_in_global=False, qptiff_in_global=False)
-        self._create_channels_csv_good(
-            Path(tmp_path / "non_global/lab_processed/images/"),
-            filename=f"2nd_{self.test_csv_filename}",
+        validator = self._set_up_shared_upload_test(
+            tmp_path,
+            non_global_files={
+                0: [
+                    f"raw/images/{self.test_qptiff_filename}",
+                    f"lab_processed/images/{self.test_csv_filename}",
+                ],
+                1: [
+                    f"lab_processed/images/2nd_{self.test_csv_filename}",
+                ],
+            },
         )
         mock = Mock()
         monkeypatch.setattr(QpTiffChannelValidator, "check_qptiff_channels_file", mock)
-        validator = self._create_shared_upload_validator(
-            tmp_path,
-            {
-                0: f"raw/images/{self.test_qptiff_filename}; lab_processed/images/{self.test_csv_filename}",
-                1: f"lab_processed/images/2nd_{self.test_csv_filename}",
-            },
-        )
         validator.files_to_test
         assert validator.errors == [
             "Unable to find qptiff file for dataset row 1 in shared upload."


### PR DESCRIPTION
Addressing issues with QPTIFF validation [observed in SenNet](https://sennet-workspace.slack.com/archives/C04HH4WV2J2/p1780922091326639). A potential issue with Docker on the SenNet infrastructure remains.

- exclude `.raw.qptiff` and `.qptiff.raw` files from `QpTiffChannelValidator` and `GeoJsonTiffValidator`
- `QpTiffChannelValidator`: prevent repeating check for every row in the metadata.tsv when both required `qptiff.channels.csv` and `.qptiff` files are found in the global dir of a shared upload [[x](https://github.com/hubmapconsortium/ingest-validation-tests/pull/108/changes#diff-41a75bea332f0e8bc56433ff595e6af64f71d25a2f7d616df32212e8f15fee3dL116)]
- fixed typing
- tests