### PR TITLE
Update QPTIFF and OME TIFF location

### DIFF
--- a/src/ingest_validation_tests/geojson_tiff_validator.py
+++ b/src/ingest_validation_tests/geojson_tiff_validator.py
@@ -1,14 +1,12 @@
 import json
-import os
-import re
 from functools import cached_property
 from pathlib import Path
 
 import tifffile
 from shapely.geometry import box, shape
 from validator import (
-    OME_TIFF_GLOBS,
-    QPTIFF_REGEX,
+    OmeTiffFinder,
+    QptiffFinder,
     Validator,
     get_non_global_paths_by_row,
 )
@@ -56,7 +54,7 @@ class GeoJsonTiffValidator(Validator):
         For each data path, locate a single GeoJSON file and TIFF files.
         Returns:
             {<data_path>: {
-                "geojson": <geojson_path>,
+                "geojson": [<geojson_path>],
                 "ome_tiff": [<ome_tiff_paths>],
                 "qptiff": [<qptiff_paths>]}}
         """
@@ -68,36 +66,14 @@ class GeoJsonTiffValidator(Validator):
             geojson_file = self._get_geojson_file(path)
             if geojson_file is None:
                 continue
-            ome_tiffs = list(
-                set(
-                    f
-                    for glob_expr in OME_TIFF_GLOBS
-                    for f in path.glob(glob_expr)
-                    if not self._is_in_extras(f)
-                )
-            )
-            qptiffs = self._get_qptiffs_for_data_path(path)
+            ome_tiffs = OmeTiffFinder(path).find()
+            qptiffs = QptiffFinder(path).find()
             files_to_test[path] = {
                 "geojson": [geojson_file],
                 "ome_tiff": ome_tiffs,
                 "qptiff": qptiffs,
             }
         return files_to_test
-
-    def _get_qptiffs_for_data_path(self, data_path: Path) -> list[Path]:
-        """
-        Exclude any QPTIFF files in extras/ or with .raw/raw. in the filename.
-        """
-        qptiffs = []
-        for path, _, files in os.walk(data_path):
-            qptiffs.extend(
-                [
-                    Path(path, name)
-                    for name in files
-                    if re.search(QPTIFF_REGEX, name) and not self._is_in_extras(Path(path, name))
-                ]
-            )
-        return qptiffs
 
     def _get_geojson_file(self, path: Path) -> Path | None:
         files = list(path.glob("**/*.geojson"))
@@ -127,15 +103,8 @@ class GeoJsonTiffValidator(Validator):
         global_ome_tiffs: list[Path] = []
         global_qptiffs: list[Path] = []
         if global_path.exists():
-            global_ome_tiffs = list(
-                set(
-                    f
-                    for glob_expr in OME_TIFF_GLOBS
-                    for f in global_path.glob(glob_expr)
-                    if not self._is_in_extras(f)
-                )
-            )
-            global_qptiffs = self._get_qptiffs_for_data_path(global_path)
+            global_ome_tiffs = OmeTiffFinder(global_path).find()
+            global_qptiffs = QptiffFinder(global_path).find()
         all_files: dict[int, dict[str, list[Path]]] = {}
         for row_num, row_paths in non_global_paths.items():
             geojson_files = [p for p in row_paths if p.suffix.lower() == ".geojson"]
@@ -148,16 +117,10 @@ class GeoJsonTiffValidator(Validator):
                 )
                 continue
             ome_tiffs = list(
-                set(
-                    [p for p in row_paths if self._is_ome_tiff(p) and not self._is_in_extras(p)]
-                    + global_ome_tiffs
-                )
+                set([p for p in row_paths if OmeTiffFinder.valid_filename(p)] + global_ome_tiffs)
             )
             qptiffs = list(
-                set(
-                    [p for p in row_paths if self._is_qptiff(p) and not self._is_in_extras(p)]
-                    + global_qptiffs
-                )
+                set([p for p in row_paths if QptiffFinder.valid_filename(p)] + global_qptiffs)
             )
             all_files[row_num] = {
                 "geojson": geojson_files,
@@ -169,16 +132,6 @@ class GeoJsonTiffValidator(Validator):
     ####################
     # TIFF validation  #
     ####################
-
-    def _is_in_extras(self, path: Path) -> bool:
-        return "extras" in path.parts
-
-    def _is_ome_tiff(self, path: Path) -> bool:
-        name = path.name.lower()
-        return name.endswith(".ome.tif") or name.endswith(".ome.tiff")
-
-    def _is_qptiff(self, path: Path) -> bool:
-        return path.name.lower().endswith(".qptiff")
 
     def _check_tiff_counts(self, ome_tiffs: list[Path], qptiffs: list[Path]) -> list[str]:
         errors = []

--- a/src/ingest_validation_tests/geojson_tiff_validator.py
+++ b/src/ingest_validation_tests/geojson_tiff_validator.py
@@ -5,10 +5,12 @@ from pathlib import Path
 import tifffile
 from shapely.geometry import box, shape
 from validator import (
-    OmeTiffFinder,
-    QptiffFinder,
+    FileTypes,
     Validator,
+    find_files,
     get_non_global_paths_by_row,
+    verify_ome_tiff_filename,
+    verify_qptiff_filename,
 )
 
 
@@ -66,8 +68,8 @@ class GeoJsonTiffValidator(Validator):
             geojson_file = self._get_geojson_file(path)
             if geojson_file is None:
                 continue
-            ome_tiffs = OmeTiffFinder(path).find()
-            qptiffs = QptiffFinder(path).find()
+            ome_tiffs = find_files(path, FileTypes.OME_TIFF)
+            qptiffs = find_files(path, FileTypes.QPTIFF)
             files_to_test[path] = {
                 "geojson": [geojson_file],
                 "ome_tiff": ome_tiffs,
@@ -103,8 +105,8 @@ class GeoJsonTiffValidator(Validator):
         global_ome_tiffs: list[Path] = []
         global_qptiffs: list[Path] = []
         if global_path.exists():
-            global_ome_tiffs = OmeTiffFinder(global_path).find()
-            global_qptiffs = QptiffFinder(global_path).find()
+            global_ome_tiffs = find_files(global_path, FileTypes.OME_TIFF)
+            global_qptiffs = find_files(global_path, FileTypes.QPTIFF)
         all_files: dict[int, dict[str, list[Path]]] = {}
         for row_num, row_paths in non_global_paths.items():
             geojson_files = [p for p in row_paths if p.suffix.lower() == ".geojson"]
@@ -117,10 +119,10 @@ class GeoJsonTiffValidator(Validator):
                 )
                 continue
             ome_tiffs = list(
-                set([p for p in row_paths if OmeTiffFinder.valid_filename(p)] + global_ome_tiffs)
+                set([p for p in row_paths if verify_ome_tiff_filename(p)] + global_ome_tiffs)
             )
             qptiffs = list(
-                set([p for p in row_paths if QptiffFinder.valid_filename(p)] + global_qptiffs)
+                set([p for p in row_paths if verify_qptiff_filename(p)] + global_qptiffs)
             )
             all_files[row_num] = {
                 "geojson": geojson_files,

--- a/src/ingest_validation_tests/ome_tiff_field_validator.py
+++ b/src/ingest_validation_tests/ome_tiff_field_validator.py
@@ -5,7 +5,7 @@ from multiprocessing import Pool
 from pathlib import Path
 
 import xmlschema
-from validator import OME_TIFF_GLOBS, Validator, check_ome_tiff_file
+from validator import OmeTiffFinder, Validator, check_ome_tiff_file
 
 
 class OmeTiffFieldValidator(Validator):
@@ -58,10 +58,8 @@ class OmeTiffFieldValidator(Validator):
             return [str(e)]
 
         filenames_to_test = []
-        for glob_expr in OME_TIFF_GLOBS:
-            for path in self.paths:
-                for file in path.glob(glob_expr):
-                    filenames_to_test.append(file)
+        for path in self.paths:
+            filenames_to_test.extend(OmeTiffFinder(path).find_all())
         if not filenames_to_test:
             return []
 

--- a/src/ingest_validation_tests/ome_tiff_field_validator.py
+++ b/src/ingest_validation_tests/ome_tiff_field_validator.py
@@ -5,7 +5,7 @@ from multiprocessing import Pool
 from pathlib import Path
 
 import xmlschema
-from validator import OmeTiffFinder, Validator, check_ome_tiff_file
+from validator import FileTypes, Validator, check_ome_tiff_file, find_all_files
 
 
 class OmeTiffFieldValidator(Validator):
@@ -59,7 +59,7 @@ class OmeTiffFieldValidator(Validator):
 
         filenames_to_test = []
         for path in self.paths:
-            filenames_to_test.extend(OmeTiffFinder(path).find_all())
+            filenames_to_test.extend(find_all_files(path, FileTypes.OME_TIFF))
         if not filenames_to_test:
             return []
 

--- a/src/ingest_validation_tests/qptiff_channel_validator.py
+++ b/src/ingest_validation_tests/qptiff_channel_validator.py
@@ -13,9 +13,10 @@ from typing import TYPE_CHECKING
 import xmlschema
 from validator import (
     BASE_OME_XML_SCHEMA,
-    QptiffFinder,
+    FileTypes,
     Validator,
     csv_to_df,
+    find_files,
     get_non_global_paths_by_row,
     get_rel_filename_str,
 )
@@ -117,7 +118,7 @@ class QpTiffChannelValidator(Validator):
     def _get_qptiff_filepath(self, parent_path: Path) -> Path | None:
         if not (Path(parent_path / "raw/images")).exists():
             return None
-        files = QptiffFinder(parent_path).find(restrict_to_expected=True)
+        files = find_files(parent_path, FileTypes.QPTIFF, restrict_to_expected=True)
         if len(files) != 1:
             self.errors.append(
                 f"Found {len(files)} QPTIFF files in {self.rel_filename_str(parent_path)} directory."

--- a/src/ingest_validation_tests/qptiff_channel_validator.py
+++ b/src/ingest_validation_tests/qptiff_channel_validator.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 import xmlschema
 from validator import (
     BASE_OME_XML_SCHEMA,
-    QPTIFF_REGEX,
+    QptiffFinder,
     Validator,
     csv_to_df,
     get_non_global_paths_by_row,
@@ -93,15 +93,57 @@ class QpTiffChannelValidator(Validator):
             if self.shared_upload:
                 files_to_test.update(self._get_shared_upload_file_pairs(path.parent))
                 break
-            channel_csv = self._get_file_path(path / "lab_processed/images", "qptiff.channels.csv")
-            qptiff_file = self._get_file_path(
-                path / "raw/images",
-                QPTIFF_REGEX,
-            )
+            self._check_required_dirs(path)
+            channel_csv = self._get_channels_filepath(path / "lab_processed/images")
+            qptiff_file = self._get_qptiff_filepath(path)
             if not (channel_csv and qptiff_file):
                 continue
             files_to_test[path] = {"csv": channel_csv, "qptiff": qptiff_file}
         return files_to_test
+
+    def _check_required_dirs(self, path: Path):
+        """
+        Log a verbose error if a required directory is missing.
+        """
+        missing_paths = []
+        for filepath in [Path(path / "raw/images"), Path(path / "lab_processed/images")]:
+            if not filepath.exists():
+                missing_paths.append(
+                    f"Did not find expected directory {self.rel_filename_str(filepath)}"
+                )
+        if missing_paths:
+            self.errors.extend(missing_paths)
+            return False
+        return True
+
+    def _get_qptiff_filepath(self, parent_path: Path) -> Path | None:
+        if not (Path(parent_path / "raw/images")).exists():
+            return None
+        files = QptiffFinder(parent_path).find(restrict_to_expected=True)
+        if len(files) != 1:
+            self.errors.append(
+                f"Found {len(files)} QPTIFF files in {self.rel_filename_str(parent_path)} directory."
+            )
+            return
+        return files[0]
+
+    def _get_channels_filepath(self, parent_path: Path) -> Path | None:
+        if not parent_path.exists():
+            return None
+        files = []
+        for filename in parent_path.iterdir():
+            if filename.name.endswith("qptiff.channels.csv"):
+                files.append(filename)
+        if len(files) != 1:
+            self.errors.append(
+                f"Found {len(files)} 'qptiff.channels.csv' files in {self.rel_filename_str(parent_path)} directory."
+            )
+            return
+        return files[0]
+
+    ##################
+    # Shared uploads #
+    ##################
 
     def _get_shared_upload_file_pairs(self, base_path: Path) -> dict[int, dict[str, Path]]:
         """
@@ -192,23 +234,6 @@ class QpTiffChannelValidator(Validator):
             self.errors.append(
                 f"Found {len(files_list)} {file_type}s ({paths_str}) for dataset in row {row} in shared upload."
             )
-
-    def _get_file_path(self, parent_path: Path, regex_str: str) -> Path | None:
-        if not parent_path.exists():
-            self.errors.append(
-                f"Did not find expected directory {self.rel_filename_str(parent_path)}"
-            )
-            return
-        files = []
-        for filename in parent_path.iterdir():
-            if re.search(re.compile(regex_str), str(filename).lower()):
-                files.append(filename)
-        if len(files) != 1:
-            self.errors.append(
-                f"Found {len(files)} files matching '{regex_str}' in {self.rel_filename_str(parent_path)} directory."
-            )
-            return
-        return files[0]
 
     ##################
     # CSV Validation #

--- a/src/ingest_validation_tests/qptiff_channel_validator.py
+++ b/src/ingest_validation_tests/qptiff_channel_validator.py
@@ -113,8 +113,6 @@ class QpTiffChannelValidator(Validator):
                 )
         if missing_paths:
             self.errors.extend(missing_paths)
-            return False
-        return True
 
     def _get_qptiff_filepath(self, parent_path: Path) -> Path | None:
         if not (Path(parent_path / "raw/images")).exists():

--- a/src/ingest_validation_tests/segmentation_mask_imagesize_validation.py
+++ b/src/ingest_validation_tests/segmentation_mask_imagesize_validation.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from tests_utils import GetParentData
-from validator import OmeTiffFinder, Validator, check_ome_tiff_file
+from validator import FileTypes, Validator, check_ome_tiff_file, find_all_files
 
 
 def get_ometiff_sizes(file) -> str | list[dict]:
@@ -73,7 +73,7 @@ class ImageSizeValidator(Validator):
                         row["parent_dataset_id"], self.token, self.app_context
                     ).get_path()
                 )
-                parent_filenames_to_test.extend(OmeTiffFinder(parent_path).find_all())
+                parent_filenames_to_test.extend(find_all_files(parent_path, FileTypes.OME_TIFF))
 
                 assert (
                     len(filenames_to_test) == 1

--- a/src/ingest_validation_tests/segmentation_mask_imagesize_validation.py
+++ b/src/ingest_validation_tests/segmentation_mask_imagesize_validation.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from tests_utils import GetParentData
-from validator import Validator, check_ome_tiff_file
+from validator import OmeTiffFinder, Validator, check_ome_tiff_file
 
 
 def get_ometiff_sizes(file) -> str | list[dict]:
@@ -46,19 +46,13 @@ class ImageSizeValidator(Validator):
         "**/segmentation_masks/*.OME.TIFF",
         "**/segmentation_masks/*.OME.TIF",
     ]
-    parent_files_to_find = [
-        "**/*.ome.tif",
-        "**/*.ome.tiff",
-        "**/*.OME.TIFF",
-        "**/*.OME.TIF",
-    ]
 
     def _collect_errors(self) -> list[str | None]:
         if not self.schema_rows:
             return ["No metadata rows found."]
         files_tested = False
         output = []
-        for i, row in enumerate(self.schema_rows):
+        for row in self.schema_rows:
             filenames_to_test = []
             parent_filenames_to_test = []
             try:
@@ -74,13 +68,12 @@ class ImageSizeValidator(Validator):
                     for file in data_path.glob(glob_expr):
                         filenames_to_test.append(file)
 
-                for glob_expr in self.parent_files_to_find:
-                    for file in Path(
-                        GetParentData(
-                            row["parent_dataset_id"], self.token, self.app_context
-                        ).get_path()
-                    ).glob(glob_expr):
-                        parent_filenames_to_test.append(file)
+                parent_path = Path(
+                    GetParentData(
+                        row["parent_dataset_id"], self.token, self.app_context
+                    ).get_path()
+                )
+                parent_filenames_to_test.extend(OmeTiffFinder(parent_path).find_all())
 
                 assert (
                     len(filenames_to_test) == 1

--- a/src/ingest_validation_tests/validator.py
+++ b/src/ingest_validation_tests/validator.py
@@ -12,10 +12,6 @@ import tifffile
 import xmlschema
 
 BASE_OME_XML_SCHEMA = Path(__file__).resolve().parent / "ome_tiff_schemas/2016-06_ome.xsd"
-OME_TIFF_GLOBS = [
-    "**/*.[oO][mM][eE].[tT][iI][fF]",
-    "**/*.[oO][mM][eE].[tT][iI][fF][fF]",
-]
 
 
 class Validator:

--- a/src/ingest_validation_tests/validator.py
+++ b/src/ingest_validation_tests/validator.py
@@ -1,6 +1,7 @@
 import inspect
 import os
 import sys
+from abc import ABC
 from csv import DictReader
 from importlib import util
 from os import cpu_count
@@ -15,7 +16,6 @@ OME_TIFF_GLOBS = [
     "**/*.[oO][mM][eE].[tT][iI][fF]",
     "**/*.[oO][mM][eE].[tT][iI][fF][fF]",
 ]
-QPTIFF_REGEX = ".*(?<!\\.raw|raw\\.)qptiff$"
 
 
 class Validator:
@@ -144,6 +144,94 @@ class Validator:
             if len(elt) == 32 and all([c in "0123456789abcdef" for c in list(elt)]):
                 return elt
         raise Exception("no uuid was found in the path to the current working directory")
+
+
+class FileFinder(ABC):
+    expected_subdir: str
+
+    def __init__(self, data_path: Path, exclude_extras: bool = True):
+        """
+        data_path: parent data path to check
+        exclude_extras: whether or not to exclude extras/ directory
+        """
+        self.data_path = data_path
+        self.exclude_extras = exclude_extras
+
+    @property
+    def expected_dir(self) -> Path:
+        return Path(self.data_path / self.expected_subdir)
+
+    def find(self, restrict_to_expected: bool = False) -> list[Path]:
+        """
+        Search for files in expected_dir; if expected_dir does not exist
+        or if no files found, search entire data_path.
+
+        Args:
+            restrict_to_expected: do not look outside of expected_dir
+        """
+        valid_files = []
+        if self.expected_dir.exists():
+            for filepath in self.expected_dir.iterdir():
+                if self.valid_filename(filepath):
+                    valid_files.append(filepath)
+        if not valid_files and not restrict_to_expected:
+            valid_files = self.find_all()
+        return valid_files
+
+    def find_all(self) -> list[Path]:
+        """
+        Recursively search entire data_path for matching files.
+        """
+        valid_files = []
+        for path, _, files in os.walk(self.data_path):
+            valid_files.extend(
+                [
+                    Path(path, filename)
+                    for filename in files
+                    if self.valid_filename(Path(path, filename), self.exclude_extras)
+                ]
+            )
+        return valid_files
+
+    @staticmethod
+    def valid_filename(file: str | Path, exclude_extras: bool = True) -> bool:
+        del file, exclude_extras
+        raise NotImplementedError()
+
+
+class QptiffFinder(FileFinder):
+    expected_subdir = "raw/images"
+
+    @staticmethod
+    def valid_filename(file: str | Path, exclude_extras: bool = True) -> bool:
+        path = Path(str(file).lower())
+        try:
+            assert path.suffix == ".qptiff"
+            assert ".raw" not in path.stem
+            assert ".intermediate" not in path.stem
+            if exclude_extras:
+                assert "extras" not in path.parts
+        except AssertionError:
+            return False
+        return True
+
+
+class OmeTiffFinder(FileFinder):
+    expected_subdir = "lab_processed/images"
+
+    @staticmethod
+    def valid_filename(file: str | Path, exclude_extras: bool = True) -> bool:
+        path = Path(str(file).lower())
+        try:
+            assert path.suffix in [".tiff", ".tif"]
+            assert ".ome.tif" in path.name
+            assert ".raw" not in path.stem
+            assert ".intermediate" not in path.stem
+            if exclude_extras:
+                assert "extras" not in path.parts
+        except AssertionError:
+            return False
+        return True
 
 
 def get_non_global_paths_by_row(rows: list[dict], base_path: Path) -> dict[int, list[Path]]:

--- a/src/ingest_validation_tests/validator.py
+++ b/src/ingest_validation_tests/validator.py
@@ -1,8 +1,8 @@
 import inspect
 import os
 import sys
-from abc import ABC
 from csv import DictReader
+from enum import Enum
 from importlib import util
 from os import cpu_count
 from pathlib import Path
@@ -57,13 +57,10 @@ class Validator:
             errors = v.collect_errors()
 
         """
-        if isinstance(base_paths, list):
-            self.paths = [Path(path) for path in base_paths]
-        elif isinstance(base_paths, (Path, str)):
+        if isinstance(base_paths, (Path, str)):
             self.paths = [Path(base_paths)]
         else:
-            # No plugin will run, halt validation
-            raise Exception(f"Validator init received base_paths arg as type {type(base_paths)}")
+            self.paths = [Path(path) for path in base_paths]
         self.assay_type = assay_type
         self.contains = contains
         self.verbose = verbose
@@ -76,12 +73,11 @@ class Validator:
         self.threads = coreuse if coreuse else num_cpus // 4 if (num_cpus and num_cpus >= 4) else 1
         self._log(f"Threading at {self.__class__.__name__} with {self.threads}")
 
-    def collect_errors(self, **kwargs) -> list[str | None]:
+    def collect_errors(self) -> list[str | None]:
         """
         Ensure plugin is valid, and if so, collect errors
         according to the subclass's _collect_errors method.
         """
-        # TODO: remove kwargs after plugin_kwargs logic is fixed upstream
         if not self.plugin_valid:
             return []
         self._log(f"Update: threading at {self.__class__.__name__} with {self.threads}")
@@ -142,92 +138,90 @@ class Validator:
         raise Exception("no uuid was found in the path to the current working directory")
 
 
-class FileFinder(ABC):
-    expected_subdir: str
-
-    def __init__(self, data_path: Path, exclude_extras: bool = True):
-        """
-        data_path: parent data path to check
-        exclude_extras: whether or not to exclude extras/ directory
-        """
-        self.data_path = data_path
-        self.exclude_extras = exclude_extras
-
-    @property
-    def expected_dir(self) -> Path:
-        return Path(self.data_path / self.expected_subdir)
-
-    def find(self, restrict_to_expected: bool = False) -> list[Path]:
-        """
-        Search for files in expected_dir; if expected_dir does not exist
-        or if no files found, search entire data_path.
-
-        Args:
-            restrict_to_expected: do not look outside of expected_dir
-        """
-        valid_files = []
-        if self.expected_dir.exists():
-            for filepath in self.expected_dir.iterdir():
-                if self.valid_filename(filepath):
-                    valid_files.append(filepath)
-        if not valid_files and not restrict_to_expected:
-            valid_files = self.find_all()
-        return valid_files
-
-    def find_all(self) -> list[Path]:
-        """
-        Recursively search entire data_path for matching files.
-        """
-        valid_files = []
-        for path, _, files in os.walk(self.data_path):
-            valid_files.extend(
-                [
-                    Path(path, filename)
-                    for filename in files
-                    if self.valid_filename(Path(path, filename), self.exclude_extras)
-                ]
-            )
-        return valid_files
-
-    @staticmethod
-    def valid_filename(file: str | Path, exclude_extras: bool = True) -> bool:
-        del file, exclude_extras
-        raise NotImplementedError()
+##############
+# Find files #
+##############
 
 
-class QptiffFinder(FileFinder):
-    expected_subdir = "raw/images"
-
-    @staticmethod
-    def valid_filename(file: str | Path, exclude_extras: bool = True) -> bool:
-        path = Path(str(file).lower())
-        try:
-            assert path.suffix == ".qptiff"
-            assert ".raw" not in path.stem
-            assert ".intermediate" not in path.stem
-            if exclude_extras:
-                assert "extras" not in path.parts
-        except AssertionError:
-            return False
-        return True
+class FileTypes(Enum):
+    QPTIFF = "raw/images"
+    OME_TIFF = "lab_processed/images"
 
 
-class OmeTiffFinder(FileFinder):
-    expected_subdir = "lab_processed/images"
+def find_files(
+    data_path: Path, file_type: FileTypes, restrict_to_expected: bool = False
+) -> list[Path]:
+    """
+    Search for files in expected_dir; if expected_dir does not exist
+    or if no files found, search entire data_path.
 
-    @staticmethod
-    def valid_filename(file: str | Path, exclude_extras: bool = True) -> bool:
-        path = Path(str(file).lower())
-        try:
-            assert path.suffix in [".tiff", ".tif"]
-            assert ".ome.tif" in path.name
-            assert ".raw" not in path.stem
-            assert ".intermediate" not in path.stem
-            if exclude_extras:
-                assert "extras" not in path.parts
-        except AssertionError:
-            return False
-        return True
+    Arguments:
+        data_path: base path to search
+        file_type: file type to search for
+        restrict_to_expected: do not look outside of expected_dir
+    """
+    valid_files = []
+    expected_dir = Path(data_path / file_type.value)
+    if expected_dir.exists():
+        for filepath in expected_dir.iterdir():
+            if verify_filename(filepath, file_type):
+                valid_files.append(filepath)
+    if not valid_files and not restrict_to_expected:
+        valid_files = find_all_files(data_path, file_type)
+    return valid_files
+
+
+def find_all_files(data_path: Path, file_type: FileTypes) -> list[Path]:
+    """
+    Recursively search entire data_path for matching files.
+    """
+    valid_files = []
+    for path, _, files in os.walk(data_path):
+        valid_files.extend(
+            [
+                Path(path, filename)
+                for filename in files
+                if verify_filename(Path(path, filename), file_type)
+            ]
+        )
+    return valid_files
+
+
+def verify_filename(filepath: Path | str, file_type: FileTypes) -> bool:
+    if file_type == FileTypes.QPTIFF:
+        return verify_qptiff_filename(filepath)
+    elif file_type == FileTypes.OME_TIFF:
+        return verify_ome_tiff_filename(filepath)
+
+
+def verify_qptiff_filename(file: str | Path) -> bool:
+    path = Path(str(file).lower())
+    try:
+        assert path.suffix == ".qptiff"
+        assert ".raw" not in path.stem
+        assert ".intermediate" not in path.stem
+        assert "extras" not in path.parts
+    except AssertionError:
+        return False
+    return True
+
+
+def verify_ome_tiff_filename(file: str | Path) -> bool:
+    path = Path(str(file).lower())
+    try:
+        assert path.suffix in [".tiff", ".tif"]
+        assert ".ome.tif" in path.name
+        assert ".raw" not in path.stem
+        assert ".intermediate" not in path.stem
+        assert "extras" not in path.parts
+    except AssertionError:
+        return False
+    return True
+
+
+#########
+# Utils #
+#########
 
 
 def get_non_global_paths_by_row(rows: list[dict], base_path: Path) -> dict[int, list[Path]]:
@@ -276,6 +270,11 @@ def check_ome_tiff_file(file: str | Path) -> xmlschema.XmlDocument:
         print(f"{file} is not a valid OME.TIFF file: {excp}")
         raise Exception(f"{file} is not a valid OME.TIFF file: {excp}")
     return xml_document
+
+
+#######
+# API #
+#######
 
 
 def validation_class_iter() -> list[Validator]:

--- a/tests/test_geojson_tiff_validator.py
+++ b/tests/test_geojson_tiff_validator.py
@@ -1,6 +1,5 @@
 import zipfile
-from pathlib import Path, PurePosixPath
-from unittest.mock import MagicMock, patch
+from pathlib import Path
 
 import pytest
 from test_tiff_validators_base_class import TestTiffValidators
@@ -81,25 +80,3 @@ class TestGeoJsonTiffValidator(TestTiffValidators):
         )
         errors = validator.collect_errors()[:]
         self.check_errors([None], errors)
-
-    def test_get_file_path(self, tmp_path):
-        good_filenames = [
-            PurePosixPath(tmp_path / "test.qptiff"),
-            PurePosixPath(tmp_path / "test_dir/extras.qptiff"),
-            PurePosixPath(tmp_path / "test_dir/test.qptiff"),
-        ]
-        bad_filenames = [
-            PurePosixPath(tmp_path / "test.qptiff.raw"),
-            PurePosixPath(tmp_path / "test.raw.qptiff"),
-            PurePosixPath(tmp_path / "test_dir/test.qptiff.raw"),
-            PurePosixPath(tmp_path / "test_dir/test.raw.qptiff"),
-            PurePosixPath(tmp_path / "test_dir/extras/test.qptiff"),
-            PurePosixPath(tmp_path / "extras/test_dir/test.qptiff"),
-        ]
-        Path(tmp_path / "test_dir/extras").mkdir(parents=True)
-        Path(tmp_path / "extras/test_dir").mkdir(parents=True)
-        for file in [*good_filenames, *bad_filenames]:
-            with open(file, "w", newline="") as mock_file:
-                mock_file.write("should be ignored")
-        validator = GeoJsonTiffValidator([tmp_path], "")
-        assert sorted(validator._get_qptiffs_for_data_path(tmp_path)) == good_filenames

--- a/tests/test_qptiff_channel_validator.py
+++ b/tests/test_qptiff_channel_validator.py
@@ -12,10 +12,8 @@ from qptiff_channel_validator import (  # type: ignore
     QpTiffChannelValidator,
 )
 
-from src.ingest_validation_tests.validator import QPTIFF_REGEX
 
-
-class TestQpTiffChannelCsv:
+class TestQpTiffChannelValidator:
 
     @pytest.mark.parametrize(
         ("test_data_fname", "msg_re_list", "assay_type"),
@@ -99,7 +97,7 @@ class TestQpTiffChannelCsv:
         errors = validator.collect_errors()[:]
         errors.sort()
         for err in [
-            "Found 0 files matching 'qptiff.channels.csv' in test_missing_channels_csv0/lab_processed/images directory.",
+            "Found 0 'qptiff.channels.csv' files in test_missing_channels_csv0/lab_processed/images directory.",
         ]:
             assert err in errors
 
@@ -210,26 +208,6 @@ class TestQpTiffChannelCsv:
         assert validator.files_to_test[Path(tmp_path)]["qptiff"] == Path(
             tmp_path / f"raw/images/{self.test_qptiff_filename}"
         )
-
-    def test_get_file_path(self, tmp_path):
-        """
-        Exclude raw.qptiff and qptiff.raw.
-        Exclude qptiffs in subdirectories.
-        """
-        good_filename = "test.qptiff"
-        bad_filenames = [
-            "test.qptiff.raw",
-            "test.raw.qptiff",
-            "test_dir/test.qptiff",
-            "test_dir/test.qptiff.raw",
-            "test_dir/test.raw.qptiff",
-        ]
-        Path(tmp_path / "test_dir").mkdir()
-        for file in [good_filename, *bad_filenames]:
-            with open(Path(tmp_path / file), "w", newline="") as mock_file:
-                mock_file.write("should be ignored")
-        validator = QpTiffChannelValidator([tmp_path], "phenocycler")
-        assert validator._get_file_path(tmp_path, QPTIFF_REGEX) == tmp_path / good_filename
 
     #######################
     # Setup shared upload #

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -134,8 +134,10 @@ def test_threads_default_to_1(monkeypatch):
         assert v.threads == 1
 
 
-def create_bad_filenames(dir_path: Path, expected_dir: bool = True):
-    bad_dirs = [  # exclude bad suffix
+def create_bad_files(dir_path: Path, expected_dir: bool = True):
+    if not dir_path.exists():
+        Path(dir_path).mkdir(parents=True)
+    bad_files = [  # exclude bad suffix
         PosixPath(dir_path / "test.qptiff.raw"),
         # exclude .raw.qptiff
         PosixPath(dir_path / "test.raw.qptiff"),
@@ -143,50 +145,94 @@ def create_bad_filenames(dir_path: Path, expected_dir: bool = True):
         PosixPath(dir_path / "test.intermediate.qptiff"),
     ]
     if expected_dir:
-        bad_dirs.extend(
+        bad_files.extend(
             [  # exclude valid file in subdir if expected dir is found
                 PosixPath(dir_path / "test_dir/test.qptiff"),
                 # exclude valid file in different dir if expected dir is found
                 PosixPath(dir_path / "test.qptiff"),
             ]
         )
-    return bad_dirs
+        Path(dir_path / "test_dir").mkdir(parents=True)
+    for file in bad_files:
+        write_file(file)
+    return bad_files
 
 
-def create_good_filenames(dir_path: Path, additional_paths: list[Path] = []):
-    return [
+def create_good_files(
+    dir_path: Path, expected_dir: bool = True, additional_paths: list[Path] = []
+):
+    if not dir_path.exists():
+        Path(dir_path).mkdir(parents=True)
+    good_files = [
         PosixPath(dir_path / "extras.qptiff"),
         PosixPath(dir_path / "test.qptiff"),
     ] + additional_paths
+    if not expected_dir:
+        good_files.append(PosixPath(dir_path / "test_dir/test.qptiff"))
+        Path(dir_path / "test_dir").mkdir(parents=True)
+    for path in additional_paths:
+        if not path.parent.exists():
+            Path(path.parent).mkdir(parents=True)
+    for file in good_files:
+        write_file(file)
+    return good_files
+
+
+def create_extra_files(dir_path: Path):
+    file = PosixPath(dir_path / "extras/test.qptiff")
+    Path(dir_path / "extras").mkdir(parents=True)
+    write_file(PosixPath(dir_path / "extras/test.qptiff"))
+    return file
+
+
+def write_file(file):
+    with open(file, "w", newline="") as mock_file:
+        mock_file.write("should be ignored")
 
 
 def test_qptifffinder_good_expected_dir(tmp_path):
     expected_dir_path = Path(tmp_path / "raw/images")
-    good_filenames = create_good_filenames(expected_dir_path)
-    bad_filenames = create_bad_filenames(expected_dir_path)
-    Path(expected_dir_path).mkdir(parents=True)
-    Path(tmp_path / "raw/images/test_dir").mkdir(parents=True)
-    Path(tmp_path / "test_dir").mkdir(parents=True)
-    for file in [*good_filenames, *bad_filenames]:
-        with open(file, "w", newline="") as mock_file:
-            mock_file.write("should be ignored")
+    good_filenames = create_good_files(expected_dir_path)
+    create_bad_files(expected_dir_path)
     assert sorted(QptiffFinder(tmp_path).find()) == good_filenames
 
 
 def test_qptifffinder_no_expected_dir(tmp_path):
-    good_filenames = create_good_filenames(
-        tmp_path,
-        # should look in subdirs
-        additional_paths=[PosixPath(tmp_path / "test_dir/test.qptiff")],
-    )
-    extras = [PosixPath(tmp_path / "extras/test.qptiff")]
-    bad_filenames = create_bad_filenames(tmp_path, expected_dir=False) + extras
-    Path(tmp_path / "test_dir").mkdir(parents=True)
-    Path(tmp_path / "extras").mkdir(parents=True)
-    for file in [*good_filenames, *bad_filenames]:
-        with open(file, "w", newline="") as mock_file:
-            mock_file.write("should be ignored")
+    good_filenames = create_good_files(tmp_path, expected_dir=False)
+    extra = create_extra_files(tmp_path)
+    create_bad_files(tmp_path, expected_dir=False)
     assert sorted(QptiffFinder(tmp_path).find()) == good_filenames
     assert sorted(QptiffFinder(tmp_path, exclude_extras=False).find()) == sorted(
-        extras + good_filenames
+        [extra, *good_filenames]
     )
+
+
+def test_qptifffinder_no_expected_dir_restricted(tmp_path):
+    assert sorted(QptiffFinder(tmp_path).find(restrict_to_expected=True)) == []
+
+
+def test_qptifffinder_find_all(tmp_path):
+    good_filenames = create_good_files(
+        tmp_path, expected_dir=False, additional_paths=[Path(tmp_path / "raw/images/test.qptiff")]
+    )
+    create_bad_files(tmp_path, expected_dir=False)
+    extra = create_extra_files(tmp_path)
+    assert sorted(QptiffFinder(tmp_path).find_all()) == sorted(good_filenames)
+    assert sorted(QptiffFinder(tmp_path, exclude_extras=False).find_all()) == sorted(
+        [*good_filenames, extra]
+    )
+
+
+def test_qptifffinder_valid_filenames():
+    files = [
+        ("S09_TMA07_030926_Scan1.qptiff", True),
+        ("S09_TMA07_030926_Scan1_Cycle16.raw.qptiff", False),
+        ("S09_TMA07_030926_Scan1_Cycle13.intermediate.qptiff", False),
+        ("S09_TMA07_030926_Scan1_Cycle19.raw.qptiff", False),
+        ("bad_file", False),
+        ("extra.qptiff", True),
+    ]
+    for file, rslt in [*files, ("extras/good.qptiff", False)]:
+        assert QptiffFinder.valid_filename(file) == rslt
+    for file, rslt in [*files, ("extras/good.qptiff", True)]:
+        assert QptiffFinder.valid_filename(file, exclude_extras=False) == rslt

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -7,19 +7,29 @@ class ValidatorTestClass(Validator):
     version = "1.0"
     required = ["required_type"]
 
-    def __init__(self, base_paths, assay_type, contains=[], **kwargs):
+    def __init__(
+        self,
+        base_paths,
+        assay_type,
+        rslt: list[str] = [],
+        data_tested: list[str] = [],
+        contains=[],
+        schema=None,
+        app_context={},
+        coreuse=None,
+    ):
         super().__init__(
             base_paths,
             assay_type,
             contains=contains,
             verbose=True,
-            schema=None,
+            schema=schema,
             globus_token="",
-            app_context={},
-            coreuse=None,
+            app_context=app_context,
+            coreuse=coreuse,
         )
-        self.rslt = kwargs.get("rslt")
-        self.data_tested = kwargs.get("data_tested")
+        self.rslt = rslt
+        self.data_tested = data_tested
 
     def _collect_errors(self):
         return self._return_result(self.rslt, self.data_tested)

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,6 +1,13 @@
 from pathlib import Path, PosixPath
 
-from validator import QptiffFinder, Validator
+from validator import (
+    FileTypes,
+    Validator,
+    find_all_files,
+    find_files,
+    verify_filename,
+    verify_qptiff_filename,
+)
 
 
 class ValidatorTestClass(Validator):
@@ -188,13 +195,6 @@ def create_good_files(
     return good_files
 
 
-def create_extra_files(dir_path: Path):
-    file = PosixPath(dir_path / "extras/test.qptiff")
-    Path(dir_path / "extras").mkdir(parents=True)
-    write_file(PosixPath(dir_path / "extras/test.qptiff"))
-    return file
-
-
 def write_file(file):
     with open(file, "w", newline="") as mock_file:
         mock_file.write("should be ignored")
@@ -204,21 +204,17 @@ def test_qptifffinder_good_expected_dir(tmp_path):
     expected_dir_path = Path(tmp_path / "raw/images")
     good_filenames = create_good_files(expected_dir_path)
     create_bad_files(expected_dir_path)
-    assert sorted(QptiffFinder(tmp_path).find()) == good_filenames
+    assert sorted(find_files(tmp_path, FileTypes.QPTIFF)) == sorted(good_filenames)
 
 
 def test_qptifffinder_no_expected_dir(tmp_path):
     good_filenames = create_good_files(tmp_path, expected_dir=False)
-    extra = create_extra_files(tmp_path)
     create_bad_files(tmp_path, expected_dir=False)
-    assert sorted(QptiffFinder(tmp_path).find()) == good_filenames
-    assert sorted(QptiffFinder(tmp_path, exclude_extras=False).find()) == sorted(
-        [extra, *good_filenames]
-    )
+    assert sorted(find_files(tmp_path, FileTypes.QPTIFF)) == sorted(good_filenames)
 
 
 def test_qptifffinder_no_expected_dir_restricted(tmp_path):
-    assert sorted(QptiffFinder(tmp_path).find(restrict_to_expected=True)) == []
+    assert sorted(find_files(tmp_path, FileTypes.QPTIFF, restrict_to_expected=True)) == []
 
 
 def test_qptifffinder_find_all(tmp_path):
@@ -226,11 +222,7 @@ def test_qptifffinder_find_all(tmp_path):
         tmp_path, expected_dir=False, additional_paths=[Path(tmp_path / "raw/images/test.qptiff")]
     )
     create_bad_files(tmp_path, expected_dir=False)
-    extra = create_extra_files(tmp_path)
-    assert sorted(QptiffFinder(tmp_path).find_all()) == sorted(good_filenames)
-    assert sorted(QptiffFinder(tmp_path, exclude_extras=False).find_all()) == sorted(
-        [*good_filenames, extra]
-    )
+    assert sorted(find_all_files(tmp_path, FileTypes.QPTIFF)) == sorted(good_filenames)
 
 
 def test_qptifffinder_valid_filenames():
@@ -241,8 +233,8 @@ def test_qptifffinder_valid_filenames():
         ("S09_TMA07_030926_Scan1_Cycle19.raw.qptiff", False),
         ("bad_file", False),
         ("extra.qptiff", True),
+        ("extras/good.qptiff", False),
     ]
-    for file, rslt in [*files, ("extras/good.qptiff", False)]:
-        assert QptiffFinder.valid_filename(file) == rslt
-    for file, rslt in [*files, ("extras/good.qptiff", True)]:
-        assert QptiffFinder.valid_filename(file, exclude_extras=False) == rslt
+    for file, rslt in files:
+        assert verify_filename(file, FileTypes.QPTIFF) == rslt
+        assert verify_qptiff_filename(file) == rslt

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,33 +1,22 @@
-import os
+from pathlib import Path, PosixPath
 
-from validator import Validator
+from validator import QptiffFinder, Validator
 
 
 class ValidatorTestClass(Validator):
     version = "1.0"
     required = ["required_type"]
 
-    def __init__(
-        self,
-        base_paths,
-        assay_type,
-        contains=[],
-        verbose=True,
-        schema=None,
-        globus_token="",
-        app_context={},
-        coreuse=None,
-        **kwargs
-    ):
+    def __init__(self, base_paths, assay_type, contains=[], **kwargs):
         super().__init__(
             base_paths,
             assay_type,
             contains=contains,
-            verbose=verbose,
-            schema=schema,
-            globus_token=globus_token,
-            app_context=app_context,
-            coreuse=coreuse,
+            verbose=True,
+            schema=None,
+            globus_token="",
+            app_context={},
+            coreuse=None,
         )
         self.rslt = kwargs.get("rslt")
         self.data_tested = kwargs.get("data_tested")
@@ -143,3 +132,61 @@ def test_threads_default_to_1(monkeypatch):
         m.setattr("validator.cpu_count", lambda: 0)
         v = ValidatorTestClass(["tmp_path"], "required_type", **default_kwargs)
         assert v.threads == 1
+
+
+def create_bad_filenames(dir_path: Path, expected_dir: bool = True):
+    bad_dirs = [  # exclude bad suffix
+        PosixPath(dir_path / "test.qptiff.raw"),
+        # exclude .raw.qptiff
+        PosixPath(dir_path / "test.raw.qptiff"),
+        # exclude .intermediate.qptiff
+        PosixPath(dir_path / "test.intermediate.qptiff"),
+    ]
+    if expected_dir:
+        bad_dirs.extend(
+            [  # exclude valid file in subdir if expected dir is found
+                PosixPath(dir_path / "test_dir/test.qptiff"),
+                # exclude valid file in different dir if expected dir is found
+                PosixPath(dir_path / "test.qptiff"),
+            ]
+        )
+    return bad_dirs
+
+
+def create_good_filenames(dir_path: Path, additional_paths: list[Path] = []):
+    return [
+        PosixPath(dir_path / "extras.qptiff"),
+        PosixPath(dir_path / "test.qptiff"),
+    ] + additional_paths
+
+
+def test_qptifffinder_good_expected_dir(tmp_path):
+    expected_dir_path = Path(tmp_path / "raw/images")
+    good_filenames = create_good_filenames(expected_dir_path)
+    bad_filenames = create_bad_filenames(expected_dir_path)
+    Path(expected_dir_path).mkdir(parents=True)
+    Path(tmp_path / "raw/images/test_dir").mkdir(parents=True)
+    Path(tmp_path / "test_dir").mkdir(parents=True)
+    for file in [*good_filenames, *bad_filenames]:
+        with open(file, "w", newline="") as mock_file:
+            mock_file.write("should be ignored")
+    assert sorted(QptiffFinder(tmp_path).find()) == good_filenames
+
+
+def test_qptifffinder_no_expected_dir(tmp_path):
+    good_filenames = create_good_filenames(
+        tmp_path,
+        # should look in subdirs
+        additional_paths=[PosixPath(tmp_path / "test_dir/test.qptiff")],
+    )
+    extras = [PosixPath(tmp_path / "extras/test.qptiff")]
+    bad_filenames = create_bad_filenames(tmp_path, expected_dir=False) + extras
+    Path(tmp_path / "test_dir").mkdir(parents=True)
+    Path(tmp_path / "extras").mkdir(parents=True)
+    for file in [*good_filenames, *bad_filenames]:
+        with open(file, "w", newline="") as mock_file:
+            mock_file.write("should be ignored")
+    assert sorted(QptiffFinder(tmp_path).find()) == good_filenames
+    assert sorted(QptiffFinder(tmp_path, exclude_extras=False).find()) == sorted(
+        extras + good_filenames
+    )


### PR DESCRIPTION
Location of QPTIFF and OME TIFF files standardized across plugins. Replaces `QPTIFF_REGEX` and various OME TIFF glob patterns. Should be extensible to other file types.

- `find_files()`
     - Look in expected subdir (`raw/images` for QPTIFFS and `lab_processed/images` for OME TIFFs) non-recursively first. Return valid filepaths if found.
     - If expected subdir does not exist or no files found, check entire provided `data_path` recursively. Return valid filepaths if found.
- `find_all_files()` can be used to just recursively check a specific path (skip expected path logic).
- `verify_qptiff_filename()` and `verify_ome_tiff_filename()` define what a valid filepath looks like.
     - A valid filepath must pass a set of assertions about its suffix, naming, and parent dirs to be included.
     - Case insensitive.
     - Rules out files without appropriate suffix, filenames that include `.raw`/`.intermediate`, and files in `extras/`.
     - `verify_ome_tiff_filename` locates both ".ome.tiff" and ".ome.tif".
- Implemented in:
     - GeoJsonTiffValidator
     - QpTiffChannelValidator
     - ImageSizeValidator
     - OmeTiffFieldValidator