### PR TITLE
Paired-Tag barcode validation

### DIFF
--- a/src/ingest_validation_tests/barcode_validator.py
+++ b/src/ingest_validation_tests/barcode_validator.py
@@ -5,12 +5,11 @@ from validator import Validator
 
 
 class BarcodeValidator(Validator):
-    """ """
-
-    description = ""
+    description = "Validate characters in barcodes.txt"
     cost = 1.0
     version = "1.0"
     required = ["paired-tag"]
+    allowed_regex = r"[^ACTG]"
 
     def __init__(self, base_paths, assay_type, *args, **kwargs):
         super().__init__(base_paths, assay_type, *args, **kwargs)
@@ -28,13 +27,19 @@ class BarcodeValidator(Validator):
         if barcode_file.exists():
             with open(barcode_file, "r") as f:
                 lines = f.read().splitlines()
-                # TODO: lowercase?
                 errors = [
-                    str(i + 1) for i, line in enumerate(lines) if re.search(r"[^ACTG]", line)
+                    str(i + 1)
+                    for i, line in enumerate(lines)
+                    if re.search(self.allowed_regex, line)
                 ]
                 if errors:
-                    self.errors.append(
-                        f"Only characters 'A', 'C', 'T', 'G' allowed in {self.rel_filename_str(barcode_file)}. Errors on lines {', '.join(errors)}."
-                    )
+                    if len(errors) <= 20:
+                        self.errors.append(
+                            f"Only characters 'A', 'C', 'T', 'G' allowed in {self.rel_filename_str(barcode_file)}. Errors on lines {', '.join(errors)}."
+                        )
+                    else:
+                        self.errors.append(
+                            f"Only characters 'A', 'C', 'T', 'G' allowed in {self.rel_filename_str(barcode_file)}. {len(errors)} lines have errors."
+                        )
             return True
         return False

--- a/src/ingest_validation_tests/barcode_validator.py
+++ b/src/ingest_validation_tests/barcode_validator.py
@@ -1,0 +1,40 @@
+import re
+from pathlib import Path
+
+from validator import Validator
+
+
+class BarcodeValidator(Validator):
+    """ """
+
+    description = ""
+    cost = 1.0
+    version = "1.0"
+    required = ["paired-tag"]
+
+    def __init__(self, base_paths, assay_type, *args, **kwargs):
+        super().__init__(base_paths, assay_type, *args, **kwargs)
+        self.errors: list = []
+
+    def _collect_errors(self) -> list[str | None]:
+        found = []
+        for path in self.paths:
+            if self.find_and_check_barcode_file(path):
+                found.append(path)
+        return self._return_result(self.errors, found)
+
+    def find_and_check_barcode_file(self, path: Path) -> bool:
+        barcode_file = path.joinpath("raw/barcodes.txt")
+        if barcode_file.exists():
+            with open(barcode_file, "r") as f:
+                lines = f.read().splitlines()
+                # TODO: lowercase?
+                errors = [
+                    str(i + 1) for i, line in enumerate(lines) if re.search(r"[^ACTG]", line)
+                ]
+                if errors:
+                    self.errors.append(
+                        f"Only characters 'A', 'C', 'T', 'G' allowed in {self.rel_filename_str(barcode_file)}. Errors on lines {', '.join(errors)}."
+                    )
+            return True
+        return False

--- a/src/ingest_validation_tests/barcode_validator.py
+++ b/src/ingest_validation_tests/barcode_validator.py
@@ -9,7 +9,7 @@ class BarcodeValidator(Validator):
     cost = 1.0
     version = "1.0"
     required = ["paired-tag"]
-    only_allowed_regex = r"[^ACTG]"
+    only_allowed_regex = r"[^AaCcTtGgNn]"
 
     def __init__(self, base_paths, assay_type, *args, **kwargs):
         super().__init__(base_paths, assay_type, *args, **kwargs)
@@ -33,7 +33,7 @@ class BarcodeValidator(Validator):
                     if re.search(self.only_allowed_regex, line)
                 ]
                 if errors:
-                    msg = f"Only characters 'A', 'C', 'T', 'G' allowed in {self.rel_filename_str(barcode_file)}."
+                    msg = f"Only characters 'A', 'C', 'T', 'G', 'N' (case-insensitive) allowed in {self.rel_filename_str(barcode_file)}."
                     if len(errors) <= 20:
                         self.errors.append(msg + f" Errors on lines {', '.join(errors)}.")
                     else:

--- a/src/ingest_validation_tests/barcode_validator.py
+++ b/src/ingest_validation_tests/barcode_validator.py
@@ -9,7 +9,7 @@ class BarcodeValidator(Validator):
     cost = 1.0
     version = "1.0"
     required = ["paired-tag"]
-    allowed_regex = r"[^ACTG]"
+    only_allowed_regex = r"[^ACTG]"
 
     def __init__(self, base_paths, assay_type, *args, **kwargs):
         super().__init__(base_paths, assay_type, *args, **kwargs)
@@ -30,16 +30,13 @@ class BarcodeValidator(Validator):
                 errors = [
                     str(i + 1)
                     for i, line in enumerate(lines)
-                    if re.search(self.allowed_regex, line)
+                    if re.search(self.only_allowed_regex, line)
                 ]
                 if errors:
+                    msg = f"Only characters 'A', 'C', 'T', 'G' allowed in {self.rel_filename_str(barcode_file)}."
                     if len(errors) <= 20:
-                        self.errors.append(
-                            f"Only characters 'A', 'C', 'T', 'G' allowed in {self.rel_filename_str(barcode_file)}. Errors on lines {', '.join(errors)}."
-                        )
+                        self.errors.append(msg + f" Errors on lines {', '.join(errors)}.")
                     else:
-                        self.errors.append(
-                            f"Only characters 'A', 'C', 'T', 'G' allowed in {self.rel_filename_str(barcode_file)}. {len(errors)} lines have errors."
-                        )
+                        self.errors.append(msg + f" {len(errors)} lines have errors.")
             return True
         return False

--- a/src/ingest_validation_tests/validator.py
+++ b/src/ingest_validation_tests/validator.py
@@ -120,6 +120,10 @@ class Validator:
             self._log("No errors found.")
             return [None]
         self._log("Plugin not relevant. Not run.")
+        # TODO: is this case meaningful?
+        # elif self.plugin_valid:
+        #     self._log("Plugin relevant for dataset type but no relevant files found.")
+        #     return [None]
         return []
 
     def _log(self, message):

--- a/src/ingest_validation_tests/validator.py
+++ b/src/ingest_validation_tests/validator.py
@@ -120,10 +120,6 @@ class Validator:
             self._log("No errors found.")
             return [None]
         self._log("Plugin not relevant. Not run.")
-        # TODO: is this case meaningful?
-        # elif self.plugin_valid:
-        #     self._log("Plugin relevant for dataset type but no relevant files found.")
-        #     return [None]
         return []
 
     def _log(self, message):

--- a/tests/test_barcode_validator.py
+++ b/tests/test_barcode_validator.py
@@ -1,0 +1,87 @@
+from pathlib import Path
+
+from barcode_validator import BarcodeValidator
+
+
+class TestBarcodeValidator:
+    def create_file(self, dir_path: Path, contents: list[str]):
+        Path(dir_path / "raw").mkdir(parents=True, exist_ok=True)
+        new_file = Path(dir_path / "raw/barcodes.txt")
+        with open(new_file, "a") as f:
+            for line in contents:
+                f.write(f"{line}\n")
+
+    def test_good_file(self, tmp_path):
+        contents = ["AGCT", "GACT", "TTTT"]
+        self.create_file(tmp_path, contents)
+        v = BarcodeValidator([tmp_path], "Paired-Tag")
+        assert v.find_and_check_barcode_file(tmp_path) == True
+        assert not v.errors
+
+    def test_bad_file_with_other_letters(self, tmp_path):
+        contents = ["HGCT", "GADT", "TTTT", "BBBB"]
+        self.create_file(tmp_path, contents)
+        v = BarcodeValidator([tmp_path], "Paired-Tag")
+        assert v.find_and_check_barcode_file(tmp_path) == True
+        assert len(v.errors) == 1
+        assert "Errors on lines 1, 2, 4." in v.errors[0]
+
+    def test_bad_file_with_numbers(self, tmp_path):
+        contents = ["2GCT", "GA1T", "TTTT", "444"]
+        self.create_file(tmp_path, contents)
+        v = BarcodeValidator([tmp_path], "Paired-Tag")
+        assert v.find_and_check_barcode_file(tmp_path) == True
+        assert len(v.errors) == 1
+        assert "Errors on lines 1, 2, 4." in v.errors[0]
+
+    def test_bad_file_with_special_characters(self, tmp_path):
+        contents = ["AGCT", "GA#T", "8CT$", "TTTT", "></+"]
+        self.create_file(tmp_path, contents)
+        v = BarcodeValidator([tmp_path], "Paired-Tag")
+        assert v.find_and_check_barcode_file(tmp_path) == True
+        assert len(v.errors) == 1
+        assert "Errors on lines 2, 3, 5." in v.errors[0]
+
+    def test_bad_file_with_whitespace(self, tmp_path):
+        contents = ["AGCT", "TTTT", "GA T", "ACTG ", " "]
+        self.create_file(tmp_path, contents)
+        v = BarcodeValidator([tmp_path], "Paired-Tag")
+        assert v.find_and_check_barcode_file(tmp_path) == True
+        assert len(v.errors) == 1
+        assert "Errors on lines 3, 4, 5." in v.errors[0]
+
+    def test_bad_file_multiple_issues(self, tmp_path):
+        contents = ["AGCT", "T2TT", "GABT", " ACTG", " ", "4", "ATCG"]
+        self.create_file(tmp_path, contents)
+        v = BarcodeValidator([tmp_path], "Paired-Tag")
+        assert v.find_and_check_barcode_file(tmp_path) == True
+        assert len(v.errors) == 1
+        assert "Errors on lines 2, 3, 4, 5, 6." in v.errors[0]
+
+    def test_find_file_good(self, tmp_path):
+        contents = ["AGCT", "GACT", "TTTT"]
+        self.create_file(tmp_path, contents)
+        v = BarcodeValidator([tmp_path], "Paired-Tag")
+        assert v.find_and_check_barcode_file(tmp_path) == True
+        assert v.collect_errors() == [None]
+
+    def test_find_file_good_shared_global(self, tmp_path):
+        path = Path(tmp_path / "global")
+        contents = ["AGCT", "GACT", "TTTT"]
+        self.create_file(path, contents)
+        v = BarcodeValidator([path, Path(tmp_path / "non_global")], "Paired-Tag")
+        assert v.find_and_check_barcode_file(path) == True
+        assert v.collect_errors() == [None]
+
+    def test_find_file_good_shared_nonglobal(self, tmp_path):
+        path = Path(tmp_path / "non_global")
+        contents = ["AGCT", "GACT", "TTTT"]
+        self.create_file(path, contents)
+        v = BarcodeValidator([path, Path(tmp_path / "global")], "Paired-Tag")
+        assert v.find_and_check_barcode_file(path) == True
+        assert v.collect_errors() == [None]
+
+    def test_find_file_missing(self, tmp_path):
+        v = BarcodeValidator([tmp_path], "Paired-Tag")
+        assert v.find_and_check_barcode_file(tmp_path) == False
+        assert v.collect_errors() == []

--- a/tests/test_barcode_validator.py
+++ b/tests/test_barcode_validator.py
@@ -12,7 +12,7 @@ class TestBarcodeValidator:
                 f.write(f"{line}\n")
 
     def test_good_file(self, tmp_path):
-        contents = ["AGCT", "GACT", "TTTT"]
+        contents = ["AGCT", "gact", "TTTT", "N"]
         self.create_file(tmp_path, contents)
         v = BarcodeValidator([tmp_path], "Paired-Tag")
         assert v.find_and_check_barcode_file(tmp_path) == True

--- a/tests/test_barcode_validator.py
+++ b/tests/test_barcode_validator.py
@@ -85,3 +85,8 @@ class TestBarcodeValidator:
         v = BarcodeValidator([tmp_path], "Paired-Tag")
         assert v.find_and_check_barcode_file(tmp_path) == False
         assert v.collect_errors() == []
+
+    def test_wrong_type(self, tmp_path):
+        v = BarcodeValidator([tmp_path], "WrongType")
+        assert v.plugin_valid == False
+        assert v.collect_errors() == []

--- a/tests/test_barcode_validator.py
+++ b/tests/test_barcode_validator.py
@@ -58,6 +58,14 @@ class TestBarcodeValidator:
         assert len(v.errors) == 1
         assert "Errors on lines 2, 3, 4, 5, 6." in v.errors[0]
 
+    def test_bad_file_truncate_errors(self, tmp_path):
+        contents = ["wrong"] * 21
+        self.create_file(tmp_path, contents)
+        v = BarcodeValidator([tmp_path], "Paired-Tag")
+        assert v.find_and_check_barcode_file(tmp_path) == True
+        assert len(v.errors) == 1
+        assert "21 lines have errors." in v.errors[0]
+
     def test_find_file_good(self, tmp_path):
         contents = ["AGCT", "GACT", "TTTT"]
         self.create_file(tmp_path, contents)


### PR DESCRIPTION
Ensure that only allowed characters (AaCcTtGgNn) are present in barcodes file for Paired-Tag.

~~Open question: Investigating whether lowercase versions of the values are permissible. It seems like that might be allowed but I'm discussing with Sean. I don't foresee this discussion changing anything other than potentially the `only_allowed_characters` regex.~~ Added additional allowed characters.